### PR TITLE
prepend output option

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ GITHUB_WORKFLOW_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITH
 mkdir -p "$(dirname $LYCHEE_TMP)"
 
 # Execute lychee
-lychee "$@" --output "$LYCHEE_TMP"
+lychee --output "$LYCHEE_TMP" "$@"
 exit_code=$?
 
 # If link errors were found, create a report in the designated directory


### PR DESCRIPTION
fix #22

Some lychee options can take multiple arguments, e.g. the `--exclude`
options. When using those options, one then needs to separate the list
of files to check by a double dash `--` [1].

The problem: `lychee-action` appends `--output /tmp/lychee/out.md` to
the command line, which is then interpreted as another input file:
```
lychee --exclude www.abc.de www.cde.de -- codes.md --output /tmp/lychee/out.md
Error: Failed to read file: `--output`, reason: No such file or directory (os error 2)
```

Instead of appending the `--output` option, this switches to prepending
it.

[1] https://github.com/lycheeverse/lychee/issues/113