### PR TITLE
Pin lychee version to specific SHA (#19)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lycheeverse/lychee:latest
+FROM lycheeverse/lychee:0.7.1@sha256:ff7c1b7490ed7e3cf5afc42ddf7ed32321291ae3e8c313214a074bb171117a3b
 
 LABEL maintainer="Matthias Endler <matthias-endler@gmx.net>"
 LABEL repository="https://github.com/lycheeverse/lychee-action"


### PR DESCRIPTION
This ensures fewer breaking changes in the future.
Users can still profit from changes but they have to opt-in by using an explicit version of the plugin like `lycheeverse/lychee-action@v1.0.8`
or `lycheeverse/lychee-action@v1` if they want to be more up-to-date at the risk of a higher change-rate.