### PR TITLE
Add dependabot, switch to SHA action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+
+updates:
+
+  # Keep dependencies for GitHub Actions up-to-date
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -10,7 +10,7 @@ jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
 
       - name: Link Checker
         uses: ./ # Uses an action in the root directory

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -10,7 +10,7 @@ jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97
 
       - name: Link Checker
         uses: ./ # Uses an action in the root directory
@@ -18,7 +18,7 @@ jobs:
           args: --verbose --no-progress --exclude lycheeverse/lychee-action@.* -- **/*.md **/*.html
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        
+
       - name: Create Issue From File
         uses: peter-evans/create-issue-from-file@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
       # To use this repository's private action,
       # you must check out the repository
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97
       - name: link checking
         uses: ./ # Uses an action in the root directory
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
       # To use this repository's private action,
       # you must check out the repository
       - name: Checkout
-        uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - name: link checking
         uses: ./ # Uses an action in the root directory
         with:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97
+      - uses: actions/checkout@v2
 
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.1.0

--- a/README.md
+++ b/README.md
@@ -94,6 +94,19 @@ When you add or update the `dependabot.yml` file, this triggers an immediate che
 Please see [the documentation](https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 ) for all configuration options.
 
+### Security tip
+
+For additional security when relying on automation to update actions you can pin the action to a SHA-256 rather than the semver version so as to avoid tag spoofing
+Dependabot will still be able to automatically update this.
+
+For example:
+
+```yml
+- name: Link Checker
+  uses: lycheeverse/lychee-action@5d7c1537c3b260f2c718b64eb36a6db6a2430e9b #1.1.0
+  #...
+```
+
 ## Credits
 
 This action is based on [peter-evans/link-checker](https://github.com/peter-evans/link-checker) and uses lychee (written in Rust) instead of liche (written in Go) for link checking. For a comparison of both tools, check out this [comparison table](https://github.com/lycheeverse/lychee#features).

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97
 
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.1.0
@@ -33,7 +33,7 @@ jobs:
           args: --verbose --no-progress **/*.md **/*.html
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        
+
       - name: Create Issue From File
         uses: peter-evans/create-issue-from-file@v3
         with:
@@ -76,7 +76,7 @@ A full CI run to scan 576 links takes approximately 1 minute for the [analysis-t
 
 It is recommended to pin lychee-action to a fixed version [for security reasons](https://francoisbest.com/posts/2020/the-security-of-github-actions).
 You can use dependabot to automatically keep your Github actions up-to-date.
-This is a great way to pin lychee-action, while still receiving updates in the future. 
+This is a great way to pin lychee-action, while still receiving updates in the future.
 It's a relatively easy thing to do.
 
 Create a file named `.github/dependabot.yml` with the following contents:


### PR DESCRIPTION
In the link from the README about security (https://francoisbest.com/posts/2020/the-security-of-github-actions) it mentions the risk of using release tags rather than SHAs to reference dependencies in the workflow.
Additionally I note that there is no dependabot keeping these pinned actions up to date.

This PR does several things:

- Change workflow action semver pins to SHA pins
- Add dependabot
- Update the README examples from semver pins to SHA pins 

The impact for this repo is:

- Dependabot creates PRs for action releases, even minor version releases, that will need reviewing and merging
- Manual updates required for the SHAs in the README examples (i.e. actions/checkout and lycheeverse/lychee)
