### PR TITLE
Fix regression on having `--format` on `args` input

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,7 @@ mkdir -p "$(dirname $LYCHEE_TMP)"
 ARGS="$@"
 [[ "$ARGS" =~ "--format " ]] || ARGS="$ARGS --format markdown"
 # Execute lychee
-lychee --output "$LYCHEE_TMP" "$ARGS"
+lychee --output "$LYCHEE_TMP" $ARGS
 exit_code=$?
 
 # If link errors were found, create a report in the designated directory

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,8 +8,10 @@ GITHUB_WORKFLOW_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITH
 # Create temp dir
 mkdir -p "$(dirname $LYCHEE_TMP)"
 
+ARGS="$@"
+[[ "$ARGS" =~ "--format " ]] || ARGS="$ARGS --format markdown"
 # Execute lychee
-lychee --format markdown --output "$LYCHEE_TMP" "$@"
+lychee --output "$LYCHEE_TMP" "$ARGS"
 exit_code=$?
 
 # If link errors were found, create a report in the designated directory


### PR DESCRIPTION
Now if one passes `--format x` to `args` input, the default format option won't be used.  

Closes #35

I didn't tested this action locally, only the bash script logic.