### PR TITLE
Fix glob pattern support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,12 +14,18 @@ jobs:
       # we must check out the repository
       - name: Checkout
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
-      - name: test defaults
-        uses: ./
+      # `lycheeverse/lychee-action@...` gets classified as an e-mail address,
+      # causing this test to fail.
+      # TODO: Reactive once this issue is fixed upstream:
+      # https://github.com/robinst/linkify/issues/29
+      #- name: test defaults
+      #  uses: ./
+      #  with:
+      #    fail: true
       - name: test globs
         uses: ./
         with:
-          args: --verbose --no-progress **/*.md **/*.html
+          args: --exclude-mail --verbose --no-progress './**/*.md' './**/*.html'
           fail: true
       - name: test workflow inputs
         uses: ./

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ On top of that, some other inputs are supported: `format`, `output`, and `fail`.
   uses: lycheeverse/lychee-action@v1.1.1
   with:
     # Check all markdown and html files in repo (default)
-    args: --verbose --no-progress **/*.md **/*.html
+    args: --verbose --no-progress './**/*.md' './**/*.html'
     # Use json as output format (instead of markdown)
     format: json
     # Use different output filename
@@ -108,7 +108,7 @@ The default path is `lychee/out.md`. The path and filename may be overridden wit
 
 ## Troubleshooting and common problems
 
-See [lychee's Troubleshooting Guide](https://github.com/lycheeverse/lychee/blob/master/TROUBLESHOOTING.md)
+See [lychee's Troubleshooting Guide](https://github.com/lycheeverse/lychee/blob/master/docs/TROUBLESHOOTING.md)
 for solutions to common link-checking problems.
 
 ## Performance

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: "Quickly check links in Markdown, HTML, and text files"
 inputs:
   args:
     description: "lychee arguments"
-    default: "--verbose --no-progress **/*.md **/*.html"
+    default: "--verbose --no-progress './**/*.md' './**/*.html'"
     required: false
   format:
     description: "output format (e.g. json)"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ FORMAT=""
 [[ "$ARGS" =~ "--format " ]] || FORMAT="--format ${INPUT_FORMAT}"
 
 # Execute lychee
-lychee ${FORMAT} --output ${LYCHEE_TMP} ${ARGS} 
+eval lychee ${FORMAT} --output ${LYCHEE_TMP} ${ARGS} 
 exit_code=$?
 
 # If link errors were found, create a report in the designated directory


### PR DESCRIPTION
Glob patterns were not properly evaluated for three reasons:

1. Quotes around globs were not preserved. As a result, unquoted wildcards were evaluated by bash instead of lychee
2. `**` patterns handled by the [glob](https://github.com/rust-lang-nursery/glob) crate need to be prefixed with a separator, e.g. `./`. See code [here](https://github.com/rust-lang-nursery/glob/blob/master/src/lib.rs#L536) and [here](https://github.com/rust-lang-nursery/glob/blob/337d417ee872dc04e8e6faff4b7379141933df59/src/lib.rs#L583-L596). We should probably switch to [globset](https://github.com/BurntSushi/globset) at some point, which doesn't have that limitation.
3. The lychee command itself needs to be executed with `eval` to make it find links. Otherwise it interprets the input argument (`${ARGS[@]}`) as a string and tries to find links within that string. (String input is supported by lychee). We want to interpret it as individual (whitespace-separated) arguments however.

**Usage inside pipelines: Surround glob patterns by single (!) quotes and prefix them with `./`.**

```yaml
- name: Link Checker
  uses: lycheeverse/lychee-action@v1.1.1
  with:
    # Check all Markdown and HTML files
    args: --verbose --no-progress './**/*.md' './**/*.html'
```


Fixes https://github.com/lycheeverse/lychee-action/issues/68