### PR TITLE
Use > as redirect operator for output files

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,7 +20,7 @@ exit_code=$?
 # If link errors were found, create a report in the designated directory
 if [ $exit_code -ne 0 ]; then
     mkdir -p "$(dirname -- "${INPUT_OUTPUT}")"
-    cat "${LYCHEE_TMP}" >> "${INPUT_OUTPUT}"
+    cat "${LYCHEE_TMP}" > "${INPUT_OUTPUT}"
     echo "[Full Github Actions output](${GITHUB_WORKFLOW_URL})" >> "${INPUT_OUTPUT}"
 fi
 


### PR DESCRIPTION
Seeing multiple failure of the default out.md file missing, so assuming this change would be able to fix the issue. I maybe wrong in my assumption. Failed Github action runs:

- https://github.com/balena-io/docs/runs/5267559383?check_suite_focus=true
- https://github.com/balena-io/docs/runs/5250397725?check_suite_focus=true

Right now runs are passing even though the error code might suggest that the run failed. But, I probably don't have the right idea behind this. 

> “>” overwrites an already existing file or a new file is created providing the mentioned file name isn’t there in the directory. This means that while making changes in a file you need to overwrite certain any existing data, use the “>” operator.
