### PR TITLE
Fail pipeline on error by default (fixes #71)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,6 @@ jobs:
 
       - name: test defaults
         uses: ./
-        with:
-          fail: true
 
       - name: test explicit lychee version
         uses: ./
@@ -39,7 +37,6 @@ jobs:
             './**/*.md'
             './**/*.html'
             './**/*.rst'
-          fail: true
 
       - name: test --base argument
         uses: ./
@@ -51,7 +48,6 @@ jobs:
             './**/*.md'
             './**/*.html'
             './**/*.rst'
-          fail: true
 
       - name: test custom output relative path - creation
         uses: ./
@@ -136,7 +132,6 @@ jobs:
           args: -v fixtures/TEST.md
           format: json
           output: ${{ github.workspace }}/foo_md.json
-          fail: true
 
       - name: Validate JSON - Markdown
         run: |
@@ -151,7 +146,6 @@ jobs:
           args: -v fixtures/TEST.rst
           format: json
           output: ${{ github.workspace }}/foo_rst.json
-          fail: true
 
       - name: Validate JSON - rST
         run: |
@@ -164,7 +158,6 @@ jobs:
         uses: ./
         with:
           args: --exclude-mail .
-          fail: true
 
       - name: test format override
         uses: ./
@@ -172,7 +165,6 @@ jobs:
           args: --format markdown -v fixtures/TEST.md
           format: doesnotexist # gets ignored if format set in args
           output: ${{ github.workspace }}/foo.txt
-          fail: true
 
       - name: test debug
         uses: ./

--- a/README.md
+++ b/README.md
@@ -46,43 +46,6 @@ jobs:
 If you always want to use the latest features but avoid breaking changes, you can replace the version with
 `lycheeverse/lychee-action@v1`.
 
-### Alternative approach:
-
-This will check all repository links during any git push event and for all pull
-requests. If there's an error, it will fail the action. This has the benefit of
-ensuring that during a Pull Request, no link is added that is broken and any
-existing link will be caught if they become broken. Save this under
-`.github/workflows/links-fail-fast.yml`:
-
-```yaml
-name: Links (Fail Fast)
-
-on:
-  push:
-  pull_request:
-
-jobs:
-  linkChecker:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Link Checker
-        uses: lycheeverse/lychee-action@v1.9.0
-        with:
-          fail: true
-```
-
-You may want to add additional arguments to the above. In particular, if you're testing a site directly from the file system (as in the above), you'll likely want to set the argument `--base .` to ensure that **all links** (including root-relative paths) in the files are tested. You don't need to do this if you're testing a hosted site.
-
-```yaml
-      - name: Link Checker
-        uses: lycheeverse/lychee-action@v1.9.0
-        with:
-          fail: true
-          args: --base . --verbose --no-progress './**/*.md' './**/*.html' './**/*.rst'
-```
-
 ## Passing arguments
 
 This action uses [lychee] for link checking.
@@ -119,8 +82,8 @@ Here is how to pass the arguments.
     output: /tmp/foo.txt
     # Use a custom GitHub token, which 
     token: ${{ secrets.CUSTOM_TOKEN }}
-    # Fail action on broken links
-    fail: true
+    # Don't fail action on broken links
+    fail: false
 ```
 
 (If you need a token that requires permissions that aren't available in the

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     required: false
   fail:
     description: "Fail entire pipeline on error (i.e. when lychee exit code is not 0)"
-    default: false
+    default: true
     required: false
   failIfEmpty:
     description: "Fail entire pipeline if no links were found"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,8 +64,9 @@ fi
 # Pass lychee exit code to next step
 echo "lychee_exit_code=$exit_code" >> $GITHUB_ENV
 
-# If `fail` is set to `true`, propagate the real exit code to the workflow
-# runner. This will cause the pipeline to fail on `exit != 0`.
+# If `fail` is set to `true` (and it is by default), propagate the real exit
+# value to the workflow runner. This will cause the pipeline to fail on 
+# `exit != # 0`.
 if [ "$INPUT_FAIL" = true ] ; then
     exit ${exit_code}
 fi


### PR DESCRIPTION
Previously, a pipeline would fail if `fail` was set to `true`. In the beginning I wasn't sure if this should be the default, so this is an opt-in. Feedback from users showed that not failing the pipeline on broken links is somewhat unexpected (compare #71). Therefore I'd like to change this and make failing the default.

Since this a potentially breaking change, I consider releasing this as part of v2.0.0.

@dkarlovi fyi