### PR TITLE
Add fail if empty argument (fixes #84)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: "output file"
     default: "lychee/out.md"
     required: false
+  fail-if-empty:
+    description: "fail entire pipeline if no links were found"
+    default: true
+    required: false
   fail:
     description: "fail entire pipeline on error (exit code not 0)"
     default: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,6 +21,17 @@ if [ ! -f "${LYCHEE_TMP}" ]; then
     echo "No output. Check pipeline run to see if lychee panicked." > "${LYCHEE_TMP}"
 fi
 
+# Overwrite the error code in case no links were found
+# and `fail-if-empty` is set to `true` (and it is by default)
+if [ "${INPUT_FAIL_IF_EMPTY}" = true ]; then
+    # This is a somewhat crude way to check the Markdown output of lychee
+    if echo "${LYCHEE_TMP}" | grep -E 'Total\s+\|\s+0'; then
+        echo "No links were found. This usually indicates a configuration error." >> "${LYCHEE_TMP}"
+        echo "If this was expected, set 'fail-if-empty: true' in the args." >> "${LYCHEE_TMP}"
+        exit_code=1
+    fi
+fi
+
 # If link errors were found, create a report in the designated directory
 if [ $exit_code -ne 0 ]; then
     mkdir -p "$(dirname -- "${INPUT_OUTPUT}")"
@@ -37,6 +48,6 @@ echo ::set-output name=exit_code::$exit_code
 
 # If `fail` is set to `true`, propagate the real exit value to the workflow
 # runner. This will cause the pipeline to fail on exit != 0.
-if [ "$INPUT_FAIL" = true ] ; then
+if [ "$INPUT_FAIL" = true ]; then
     exit ${exit_code}
 fi


### PR DESCRIPTION
If no links were found during a run, this could indicate a configuration
issue. In order to warn users, this new option allows failing the pipeline
in such a scenario.
I'm planning to merge this as part of v2.0.0 and it will be on by default.

See https://github.com/lycheeverse/lychee-action/issues/84