### PR TITLE
Fix condition in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Create Issue From File
-        if: ${{ steps.lychee.outputs.exit_code }} != 0
+        if: steps.lychee.outputs.exit_code != 0
         uses: peter-evans/create-issue-from-file@v3
         with:
           title: Link Checker Report


### PR DESCRIPTION
The README contains an example which is supposed to conditionally run `peter-evans/create-issue-from-file` if the `lychee` action returns a non-zero exit code. However, `${{ steps.lychee.outputs.exit_code }} != 0` actually evaluates to `false` even if `exit_code` is `0` (which is very surprising behaviour tbf). This PR fixes the example so that it behaves as expected.