### PR TITLE
Add support for Github Job Summaries

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
    same "printed page" as the copyright notice for easier
    identification within third-party archives.
 
-Copyright 2020 The lychee maintainers
+Copyright 2022 The lychee maintainers
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 The lychee maintainers
+Copyright (c) 2022 The lychee maintainers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -5,14 +5,16 @@
 
 Quickly check links in Markdown, HTML, and text files using [lychee].
 
-When used in conjunction with [Create Issue From File](https://github.com/peter-evans/create-issue-from-file), issues will be created when the action finds link problems.
+When used in conjunction with [Create Issue From
+File](https://github.com/peter-evans/create-issue-from-file), issues will be
+created when the action finds link problems.
 
 ## Usage
 
 Here is a full example of a GitHub workflow file:
 
-It will check all repository links once per day and create an issue in case of errors.
-Save this under `.github/workflows/links.yml`:
+It will check all repository links once per day and create an issue in case of
+errors. Save this under `.github/workflows/links.yml`:
 
 ```yaml
 name: Links
@@ -31,7 +33,7 @@ jobs:
 
       - name: Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v1.4.1
+        uses: lycheeverse/lychee-action@v1.5.0
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
@@ -66,7 +68,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Link Checker
-        uses: lycheeverse/lychee-action@v1.4.1
+        uses: lycheeverse/lychee-action@v1.5.0
         with:
           fail: true
         env:
@@ -77,40 +79,45 @@ jobs:
 
 This action uses [lychee] for link checking.
 lychee arguments can be passed to the action via the `args` parameter.
-On top of that, some other inputs are supported: `format`, `output`, and `fail`.
+See [lychee's documentation][lychee-args] for all possible arguments.
+
+On top of that, the action also supports some additional arguments.
+
+| Argument   | Description                                                                      |
+| ---------- | -------------------------------------------------------------------------------- |
+| format     | Summary output format (markdown, json,...)                                       |
+| output     | Summary output file path                                                         |
+| fail       | Fail entire pipeline on error (i.e. when lychee exit code is not 0)              |
+| jobSummary | Write Github job summary at the end of the job (written on Markdown output only) |
+
+See [action.yml](./action.yml) for a full list of supported arguments.
+
+### Example of argument passing
 
 ```yml
 - name: Link Checker
-  uses: lycheeverse/lychee-action@v1.4.1
+  uses: lycheeverse/lychee-action@v1.5.0
   with:
     # Check all markdown and html files in repo (default)
     args: --verbose --no-progress './**/*.md' './**/*.html'
     # Use json as output format (instead of markdown)
     format: json
-    # Use different output filename
+    # Use different output file path
     output: /tmp/foo.txt
     # Fail action on broken links
     fail: true
 ```
-
-See [lychee's documentation][lychee-args] for all possible arguments.
 
 ## Excluding links from getting checked
 
 Add a `.lycheeignore` file to the root of your repository to exclude links from
 getting checked. It supports regular expressions. One expression per line.
 
-## Optional environment variables
-
-Issues with links will be written to a file containing the error report.
-The default path is `lychee/out.md`. The path and filename may be overridden with the following variable:
-
-- `LYCHEE_OUT` - The path to the output file for the Markdown error report
-
 ## Fancy badge
 
-Pro tip: You can add a little badge to your repo to show the status of your links.
-Just replace `org` with your organisation name and `repo` with the repository name and put it into your `README.md`:
+Pro tip: You can add a little badge to your repo to show the status of your
+links. Just replace `org` with your organisation name and `repo` with the
+repository name and put it into your `README.md`:
 
 ```
 [![Check Links](https://github.com/org/repo/actions/workflows/links.yml/badge.svg)](https://github.com/org/repo/actions/workflows/links.yml)
@@ -122,19 +129,21 @@ It will look like this:
 
 ## Troubleshooting and common problems
 
-See [lychee's Troubleshooting Guide](https://github.com/lycheeverse/lychee/blob/master/docs/TROUBLESHOOTING.md)
-for solutions to common link-checking problems.
+See [lychee's Troubleshooting Guide][troubleshooting] for solutions to common
+link-checking problems.
 
 ## Performance
 
-A full CI run to scan 576 links takes approximately 1 minute for the [analysis-tools-dev/static-analysis](https://github.com/analysis-tools-dev/static-analysis) repository.
+A full CI run to scan 576 links takes approximately 1 minute for the
+[analysis-tools-dev/static-analysis](https://github.com/analysis-tools-dev/static-analysis)
+repository.
 
 ## Security and Updates
 
-It is recommended to pin lychee-action to a fixed version [for security reasons](https://francoisbest.com/posts/2020/the-security-of-github-actions).
-You can use dependabot to automatically keep your Github actions up-to-date.
-This is a great way to pin lychee-action, while still receiving updates in the future.
-It's a relatively easy thing to do.
+It is recommended to pin lychee-action to a fixed version [for security
+reasons][security]. You can use dependabot to automatically keep your Github
+actions up-to-date. This is a great way to pin lychee-action, while still
+receiving updates in the future. It's a relatively easy thing to do.
 
 Create a file named `.github/dependabot.yml` with the following contents:
 
@@ -148,12 +157,13 @@ updates:
 ```
 
 When you add or update the `dependabot.yml` file, this triggers an immediate check for version updates.
-Please see [the documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file) for all configuration options.
+Please see [the documentation][dependabot] for all configuration options.
 
 ### Security tip
 
-For additional security when relying on automation to update actions you can pin the action to a SHA-256 rather than the semver version so as to avoid tag spoofing
-Dependabot will still be able to automatically update this.
+For additional security when relying on automation to update actions you can pin
+the action to a SHA-256 rather than the semver version so as to avoid tag
+spoofing Dependabot will still be able to automatically update this.
 
 For example:
 
@@ -165,7 +175,11 @@ For example:
 
 ## Credits
 
-This action is based on [peter-evans/link-checker](https://github.com/peter-evans/link-checker) and uses lychee (written in Rust) instead of liche (written in Go) for link checking. For a comparison of both tools, check out this [comparison table](https://github.com/lycheeverse/lychee#features).
+This action is based on
+[peter-evans/link-checker](https://github.com/peter-evans/link-checker) and uses
+lychee (written in Rust) instead of liche (written in Go) for link checking. For
+a comparison of both tools, check out this [comparison
+table](https://github.com/lycheeverse/lychee#features).
 
 ## License
 
@@ -173,9 +187,12 @@ lychee is licensed under either of
 
 - Apache License, Version 2.0, (LICENSE-APACHE or
   https://www.apache.org/licenses/LICENSE-2.0)
-- MIT license (LICENSE-MIT or https://opensource.org/licenses/MIT)
+- MIT license (LICENSE-MIT or https://choosealicense.com/licenses/mit/)
 
 at your option.
 
 [lychee]: https://github.com/lycheeverse/lychee
 [lychee-args]: https://github.com/lycheeverse/lychee#commandline-parameters
+[troubleshooting]: https://github.com/lycheeverse/lychee/blob/master/docs/TROUBLESHOOTING.md
+[security]: https://francoisbest.com/posts/2020/the-security-of-github-actions
+[dependabot]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file

--- a/action.yml
+++ b/action.yml
@@ -6,16 +6,20 @@ inputs:
     default: "--verbose --no-progress './**/*.md' './**/*.html'"
     required: false
   format:
-    description: "output format (e.g. json)"
+    description: "summary output format (e.g. json)"
     default: "markdown"
     required: false
   output:
-    description: "output file"
+    description: "summary output file path"
     default: "lychee/out.md"
     required: false
   fail:
-    description: "fail entire pipeline on error (exit code not 0)"
+    description: "fail entire pipeline on error (i.e. when lychee exit code is not 0)"
     default: false
+    required: false
+  jobSummary:
+    description: "write Github job summary at the end of the job (written on Markdown output only)"
+    default: true
     required: false
 runs:
   using: "docker"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,7 +36,7 @@ cat "${LYCHEE_TMP}"
 echo
 
 if [ "${INPUT_FORMAT}" == "markdown" ]; then
-  if [ "${INPUT_JOB_SUMMARY}" = true ]; then
+  if [ "${INPUT_JOBSUMMARY}" = true ]; then
     cat "${LYCHEE_TMP}" > "${GITHUB_STEP_SUMMARY}"
   fi
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,6 +35,12 @@ fi
 cat "${LYCHEE_TMP}"
 echo
 
+if [ "${INPUT_FORMAT}" == "markdown" ]; then
+  if [ "${INPUT_JOB_SUMMARY}" = true ]; then
+    cat "${LYCHEE_TMP}" > "${GITHUB_STEP_SUMMARY}"
+  fi
+fi
+
 # Pass lychee exit code to next step
 echo ::set-output name=exit_code::$exit_code
 


### PR DESCRIPTION
GitHub Actions Job Summaries, which allow for custom Markdown content on the run summary generated by each job. We use it to generate a report of the link check and attach it to the action run overview page.

Closes https://github.com/lycheeverse/lychee-action/issues/124.