### PR TITLE
README: Expand argument table

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,14 +82,14 @@ lychee arguments can be passed to the action via the `args` parameter.
 
 On top of that, the action also supports some additional arguments.
 
-| Argument      | Examples                | Description                                                                      |
-| ------------- | ----------------------- |--------------------------------------------------------------------------------- |
-| args          | `--cache`, `--insecure` | See [lychee's documentation][lychee-args] for all possible arguments and values  |
-| format        | `markdown`, `json`      | Summary output format                                                            |
-| output        | `lychee/results.md`     | Summary output file path                                                         |
-| fail          | `true`                  | Fail entire pipeline on error (i.e. when lychee exit code is not 0)              |
-| jobSummary    | `true`                  | Write Github job summary at the end of the job (written on Markdown output only) |
-| lycheeVersion | `0.10.0`                | Overwrite the lychee version to be used                                          |
+| Argument      | Examples                | Description                                                              |
+| ------------- | ----------------------- |------------------------------------------------------------------------- |
+| args          | `--cache`, `--insecure` | See [lychee's documentation][lychee-args] for all arguments and values   |
+| format        | `markdown`, `json`      | Summary output format                                                    |
+| output        | `lychee/results.md`     | Summary output file path                                                 |
+| fail          | `false`                 | Fail workflow run on error (i.e. when lychee exit code is not 0)         |
+| jobSummary    | `false`                 | Write Github job summary (on Markdown output only)                       |
+| lycheeVersion | `0.10.0`                | Overwrite the lychee version to be used                                  |
 
 See [action.yml](./action.yml) for a full list of supported arguments and their default values.
 

--- a/README.md
+++ b/README.md
@@ -82,14 +82,14 @@ lychee arguments can be passed to the action via the `args` parameter.
 
 On top of that, the action also supports some additional arguments.
 
-| Argument      | Examples                | Description                                                              |
-| ------------- | ----------------------- |------------------------------------------------------------------------- |
-| args          | `--cache`, `--insecure` | See [lychee's documentation][lychee-args] for all arguments and values   |
-| format        | `markdown`, `json`      | Summary output format                                                    |
-| output        | `lychee/results.md`     | Summary output file path                                                 |
-| fail          | `false`                 | Fail workflow run on error (i.e. when lychee exit code is not 0)         |
-| jobSummary    | `false`                 | Write Github job summary (on Markdown output only)                       |
-| lycheeVersion | `0.10.0`                | Overwrite the lychee version to be used                                  |
+| Argument      | Examples                | Description                                                                     |
+| ------------- | ----------------------- |-------------------------------------------------------------------------------- |
+| args          | `--cache`, `--insecure` | See [lychee's documentation][lychee-args] for all arguments and values          |
+| format        | `markdown`, `json`      | Summary output format                                                           |
+| output        | `lychee/results.md`     | Summary output file path                                                        |
+| fail          | `false`                 | Fail workflow run on error (i.e. when [lychee exit code][lychee-exit] is not 0) |
+| jobSummary    | `false`                 | Write Github job summary (on Markdown output only)                              |
+| lycheeVersion | `0.10.0`                | Overwrite the lychee version to be used                                         |
 
 See [action.yml](./action.yml) for a full list of supported arguments and their default values.
 
@@ -194,6 +194,7 @@ at your option.
 
 [lychee]: https://github.com/lycheeverse/lychee
 [lychee-args]: https://github.com/lycheeverse/lychee#commandline-parameters
+[lychee-exit]: https://github.com/lycheeverse/lychee#exit-codes
 [troubleshooting]: https://github.com/lycheeverse/lychee/blob/master/docs/TROUBLESHOOTING.md
 [security]: https://francoisbest.com/posts/2020/the-security-of-github-actions
 [dependabot]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file

--- a/README.md
+++ b/README.md
@@ -82,14 +82,14 @@ lychee arguments can be passed to the action via the `args` parameter.
 
 On top of that, the action also supports some additional arguments.
 
-| Argument      | Examples                     | Description                                                                      |
-| ------------- | ---------------------------- |--------------------------------------------------------------------------------- |
-| args          | `--cache`, `--require-https` | See [lychee's documentation][lychee-args] for all possible arguments and values  |
-| format        | `markdown`, `json`           | Summary output format                                                            |
-| output        | `lychee/results.md`          | Summary output file path                                                         |
-| fail          | `true`                       | Fail entire pipeline on error (i.e. when lychee exit code is not 0)              |
-| jobSummary    | `true`                       | Write Github job summary at the end of the job (written on Markdown output only) |
-| lycheeVersion | `0.10.0`                     | Overwrite the lychee version to be used                                          |
+| Argument      | Examples                | Description                                                                      |
+| ------------- | ----------------------- |--------------------------------------------------------------------------------- |
+| args          | `--cache`, `--insecure` | See [lychee's documentation][lychee-args] for all possible arguments and values  |
+| format        | `markdown`, `json`      | Summary output format                                                            |
+| output        | `lychee/results.md`     | Summary output file path                                                         |
+| fail          | `true`                  | Fail entire pipeline on error (i.e. when lychee exit code is not 0)              |
+| jobSummary    | `true`                  | Write Github job summary at the end of the job (written on Markdown output only) |
+| lycheeVersion | `0.10.0`                | Overwrite the lychee version to be used                                          |
 
 See [action.yml](./action.yml) for a full list of supported arguments and their default values.
 

--- a/README.md
+++ b/README.md
@@ -79,17 +79,17 @@ jobs:
 
 This action uses [lychee] for link checking.
 lychee arguments can be passed to the action via the `args` parameter.
-See [lychee's documentation][lychee-args] for all possible arguments.
 
 On top of that, the action also supports some additional arguments.
 
-| Argument      | Examples           | Description                                                                      |
-| ------------- | ------------------ |--------------------------------------------------------------------------------- |
-| format        | `markdown`, `json` | Summary output format                                                            |
-| output        | *file path*        | Summary output file path                                                         |
-| fail          | `true`             | Fail entire pipeline on error (i.e. when lychee exit code is not 0)              |
-| jobSummary    | `true`             | Write Github job summary at the end of the job (written on Markdown output only) |
-| lycheeVersion | `0.10.0`           | Overwrite the lychee version to be used                                          |
+| Argument      | Examples                     | Description                                                                      |
+| ------------- | ---------------------------- |--------------------------------------------------------------------------------- |
+| args          | `--cache`, `--require-https` | See [lychee's documentation][lychee-args] for all possible arguments and values  |
+| format        | `markdown`, `json`           | Summary output format                                                            |
+| output        | `lychee/results.md`          | Summary output file path                                                         |
+| fail          | `true`                       | Fail entire pipeline on error (i.e. when lychee exit code is not 0)              |
+| jobSummary    | `true`                       | Write Github job summary at the end of the job (written on Markdown output only) |
+| lycheeVersion | `0.10.0`                     | Overwrite the lychee version to be used                                          |
 
 See [action.yml](./action.yml) for a full list of supported arguments and their default values.
 

--- a/README.md
+++ b/README.md
@@ -83,15 +83,15 @@ See [lychee's documentation][lychee-args] for all possible arguments.
 
 On top of that, the action also supports some additional arguments.
 
-| Argument      | Description                                                                      |
-| ------------- | -------------------------------------------------------------------------------- |
-| format        | Summary output format (markdown, json,...)                                       |
-| output        | Summary output file path                                                         |
-| fail          | Fail entire pipeline on error (i.e. when lychee exit code is not 0)              |
-| jobSummary    | Write Github job summary at the end of the job (written on Markdown output only) |
-| lycheeVersion | Overwrite the lychee version to be used                                          |
+| Argument      | Examples           | Description                                                                      |
+| ------------- | ------------------ |--------------------------------------------------------------------------------- |
+| format        | `markdown`, `json` | Summary output format                                                            |
+| output        | *file path*        | Summary output file path                                                         |
+| fail          | `true`             | Fail entire pipeline on error (i.e. when lychee exit code is not 0)              |
+| jobSummary    | `true`             | Write Github job summary at the end of the job (written on Markdown output only) |
+| lycheeVersion | `0.10.0`           | Overwrite the lychee version to be used                                          |
 
-See [action.yml](./action.yml) for a full list of supported arguments.
+See [action.yml](./action.yml) for a full list of supported arguments and their default values.
 
 ### Example of argument passing
 


### PR DESCRIPTION
I tried to make the docs of this great GitHub Action a bit more friendly for new people.

- Add `Examples` column to the table
- Include `args` into the table, instead having it in text above
- Mention where to find default values