### PR TITLE
Add cache example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,25 @@ See [action.yml](./action.yml) for a full list of supported arguments and their 
     fail: true
 ```
 
+## Utilising the cache feature
+
+In order to mitigate issues regarding rate limiting or to reduce stress on external resources, one can setup lychee's cache similar to this:
+
+```yml
+- name: Restore lychee cache
+  uses: actions/cache@v3
+  with:
+    path: .lycheecache
+    key: cache-lychee-${{ github.sha }}
+    restore-keys: cache-lychee-
+
+- name: Run lychee
+  uses: lycheeverse/lychee-action@v1.5.0
+  with:
+    args: '--cache --max-cache-age 1d'
+    lycheeVersion: 0.11.0
+```
+
 ## Excluding links from getting checked
 
 Add a `.lycheeignore` file to the root of your repository to exclude links from

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ On top of that, the action also supports some additional arguments.
 | output        | `lychee/results.md`     | Summary output file path                                                        |
 | fail          | `false`                 | Fail workflow run on error (i.e. when [lychee exit code][lychee-exit] is not 0) |
 | jobSummary    | `false`                 | Write Github job summary (on Markdown output only)                              |
-| lycheeVersion | `0.10.0`                | Overwrite the lychee version to be used                                         |
+| lycheeVersion | `0.10.1`                | Overwrite the lychee version to be used                                         |
 
 See [action.yml](./action.yml) for a full list of supported arguments and their default values.
 
@@ -122,10 +122,9 @@ In order to mitigate issues regarding rate limiting or to reduce stress on exter
     restore-keys: cache-lychee-
 
 - name: Run lychee
-  uses: lycheeverse/lychee-action@v1.5.0
+  uses: lycheeverse/lychee-action@v1.5.1
   with:
     args: '--cache --max-cache-age 1d'
-    lycheeVersion: 0.10.1
 ```
 
 Note that there is no need for another step at the end to store the cache.

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ In order to mitigate issues regarding rate limiting or to reduce stress on exter
   uses: lycheeverse/lychee-action@v1.5.0
   with:
     args: '--cache --max-cache-age 1d'
-    lycheeVersion: 0.11.0
+    lycheeVersion: 0.10.1
 ```
 
 Note that there is no need for another step at the end to store the cache.

--- a/README.md
+++ b/README.md
@@ -128,6 +128,13 @@ In order to mitigate issues regarding rate limiting or to reduce stress on exter
     lycheeVersion: 0.11.0
 ```
 
+Note that there is no need for another step at the end to store the cache.
+There will automatically be a `Post` step (generated from the used `actions/cache` action) taking care of that.
+It will compare and save the cache based on the given key.
+So in this setup, as long as a user triggers the CI run from the same commit, it will be the same key. The first run will save the cache, subsequent runs will not update it (because it's the same commit hash).
+For restoring the cache, the most recent available one is used (commit hash doesn't matter).
+
+
 ## Excluding links from getting checked
 
 Add a `.lycheeignore` file to the root of your repository to exclude links from


### PR DESCRIPTION
Such an example never made it to the docs after the feature got introduced (https://github.com/lycheeverse/lychee/pull/443).

Now, that https://github.com/lycheeverse/lychee/issues/647 is resolved and `--cache` works again... 👍 

What do you think about my approach and the cache setup?
Would you adjust the default cache age value, or do you think some comments could be helpful?