### PR TITLE
fix: install lychee to a user owner directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,8 @@ runs:
       run: |
         curl -sLO 'https://github.com/lycheeverse/lychee/releases/download/v${{ inputs.LYCHEEVERSION }}/lychee-v${{ inputs.LYCHEEVERSION }}-x86_64-unknown-linux-gnu.tar.gz'
         tar -xvzf lychee-v${{ inputs.LYCHEEVERSION }}-x86_64-unknown-linux-gnu.tar.gz
-        install lychee /usr/local/bin/lychee
+        install -t $HOME/.local/bin -D lychee
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
       shell: bash
     - name: Run lychee
       run: ${{ github.action_path }}/entrypoint.sh


### PR DESCRIPTION
In a self-hosted context, `/usr/local/bin` may be not writable by the runner user. Use a user owned folder and add it to GitHub Actions PATH variable instead.

Tests are done. Works as expected.