### PR TITLE
Replace deprecated `::set-output` by `$GITHUB_ENV`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Create Issue From File
-        if: steps.lychee.outputs.exit_code != 0
+        if: env.lychee_exit_code != 0
         uses: peter-evans/create-issue-from-file@v4
         with:
           title: Link Checker Report

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,7 +48,7 @@ if [ "${INPUT_FORMAT}" == "markdown" ]; then
 fi
 
 # Pass lychee exit code to next step
-echo "exit_code=$exit_code" >> $GITHUB_STATE
+echo "lychee_exit_code=$exit_code" >> $GITHUB_ENV
 
 # If `fail` is set to `true`, propagate the real exit value to the workflow
 # runner. This will cause the pipeline to fail on exit != 0.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,7 +48,7 @@ if [ "${INPUT_FORMAT}" == "markdown" ]; then
 fi
 
 # Pass lychee exit code to next step
-echo ::set-output name=exit_code::$exit_code
+echo "exit_code=$exit_code" >> $GITHUB_STATE
 
 # If `fail` is set to `true`, propagate the real exit value to the workflow
 # runner. This will cause the pipeline to fail on exit != 0.


### PR DESCRIPTION
Signed-off-by: Yury-Fridlyand <yuryf@bitquilltech.com>

Fixes: #166 
