### PR TITLE
Cleanup old lychee bin after install

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
     required: false
   output:
     description: "Summary output file path"
-    default: "lychee/out.md"
+    default: "lychee/output.md"
     required: false
 outputs:
   exit_code:
@@ -41,6 +41,7 @@ runs:
         curl -sLO 'https://github.com/lycheeverse/lychee/releases/download/v${{ inputs.LYCHEEVERSION }}/lychee-v${{ inputs.LYCHEEVERSION }}-x86_64-unknown-linux-gnu.tar.gz'
         tar -xvzf lychee-v${{ inputs.LYCHEEVERSION }}-x86_64-unknown-linux-gnu.tar.gz
         install -t $HOME/.local/bin -D lychee
+        rm lychee
         echo "$HOME/.local/bin" >> $GITHUB_PATH
       shell: bash
     - name: Run lychee

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
     required: false
   output:
     description: "Summary output file path"
-    default: "lychee/output.md"
+    default: "lychee/out.md"
     required: false
 outputs:
   exit_code:


### PR DESCRIPTION
Having the lychee bin stick around after installation causes problems.

```
mkdir: cannot create directory ‘lychee’: File exists
 /home/runner/work/_actions/lycheeverse/lychee-action/xx/entrypoint.sh: line 33: lychee/out.md: Not a directory
```

This change removes the installation binary after installation.