### PR TITLE
Use random tempfile for `LYCHEE_TMP`

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ if [ "${INPUT_DEBUG}" = true ]; then
   set -x
 fi
 
-LYCHEE_TMP="/tmp/lychee/out.md"
+LYCHEE_TMP="$(mktemp)"
 GITHUB_WORKFLOW_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}?check_suite_focus=true"
 
 # Create temp dir


### PR DESCRIPTION
This prevents output overlapping when running lychee multiple times.

Note that the final output file remains unchanged.
This is on purpose because when executing lychee multiple times
within the same workflow, the output of all runs will be concatenated.
To prevent that you can set a different output path for both runs:

```yaml
      - uses: lycheeverse/lychee-action@master
        with:
          args: '<some args> -- <file1>'
          output: run1.md
          fail: true
          jobSummary: true

      - uses: lycheeverse/lychee-action@master
        with:
          args: '<some args> -- <file2>'
          output: run2.md
          fail: true
          jobSummary: true
```