### PR TITLE
Document the current directory for the cache argument example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ jobs:
 
 (You don't need to configure the `GITHUB_TOKEN` yourself; it is automatically set by Github.)
 
-If you always want to use the latest features but avoid breaking changes, you can replace the version with  
+If you always want to use the latest features but avoid breaking changes, you can replace the version with
 `lycheeverse/lychee-action@v1`.
 
 ### Alternative approach:
@@ -129,7 +129,7 @@ In order to mitigate issues regarding rate limiting or to reduce stress on exter
 - name: Run lychee
   uses: lycheeverse/lychee-action@v1.8.0
   with:
-    args: "--cache --max-cache-age 1d"
+    args: "--cache --max-cache-age 1d ."
 ```
 
 It will compare and save the cache based on the given key.
@@ -149,7 +149,7 @@ If you need more control over when caches are restored and saved, you can split 
 - name: Run lychee
   uses: lycheeverse/lychee-action@v1.8.0
   with:
-    args: "--cache --max-cache-age 1d"
+    args: "--cache --max-cache-age 1d ."
 
 - name: Save lychee cache
   uses: actions/cache/save@v3


### PR DESCRIPTION
When we provide our own `args` the command seems to be overriden and the job fails due to the `inputs` argument missing.

I don't know if it's the intended behaviour. I updated the doc so the example works.

An example of a failing job can be found here:
https://github.com/theredfish/blog/actions/runs/4991322332/jobs/8937654510