### PR TITLE
Add `*.rst` glob pattern to defaults

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Link Checker
         uses: ./ # Uses an action in the root directory
         with:
-          args: --user-agent "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:59.0) Gecko/20100101 Firefox/59.0" --verbose --exclude spinroot.com --no-progress './**/*.md' './**/*.html'
+          args: --user-agent "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:59.0) Gecko/20100101 Firefox/59.0" --verbose --exclude spinroot.com --no-progress './**/*.md' './**/*.html' './**/*.rst'
           fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,10 +33,17 @@ jobs:
             './**/*.html'
             './**/*.rst'
           fail: true
-      - name: test workflow inputs
+      - name: test workflow inputs - Markdown
         uses: ./
         with:
           args: -v fixtures/TEST.md
+          format: json
+          output: /tmp/foo.json
+          fail: true
+      - name: test workflow inputs - rST
+        uses: ./
+        with:
+          args: -v fixtures/TEST.rst
           format: json
           output: /tmp/foo.json
           fail: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
             --no-progress
             './**/*.md'
             './**/*.html'
+            './**/*.rst'
           fail: true
       - name: test workflow inputs
         uses: ./

--- a/.github/workflows/test_cache.yml
+++ b/.github/workflows/test_cache.yml
@@ -28,6 +28,7 @@ jobs:
             --no-progress
             './**/*.md'
             './**/*.html'
+            './**/*.rst'
           # Fail the action on broken links.
           # If the pipeline fails, the cache will _not_ be stored
           fail: true

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ See [action.yml](./action.yml) for a full list of supported arguments and their 
   uses: lycheeverse/lychee-action@v1.8.0
   with:
     # Check all markdown and html files in repo (default)
-    args: --verbose --no-progress './**/*.md' './**/*.html'
+    args: --verbose --no-progress './**/*.md' './**/*.html' './**/*.rst'
     # Use json as output format (instead of markdown)
     format: json
     # Use different output file path

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: "Quickly check links in Markdown, HTML, and text files"
 inputs:
   args:
     description: "Lychee arguments (https://github.com/lycheeverse/lychee#commandline-parameters)"
-    default: "--verbose --no-progress './**/*.md' './**/*.html'"
+    default: "--verbose --no-progress './**/*.md' './**/*.html' './**/*.rst'"
     required: false
   debug:
     description: "Enable debug output in action (set -x). Helpful for troubleshooting."

--- a/fixtures/TEST.rst
+++ b/fixtures/TEST.rst
@@ -1,0 +1,29 @@
+.. figure:: awesome.png
+   :alt: Logo
+
+   Logo
+
+.. figure:: #awesome
+   :alt: Anchors should be ignored
+
+   Anchors should be ignored
+
+Normal link, which should work as expected.
+`Wikipedia <https://en.wikipedia.org/wiki/Static_program_analysis>`__
+
+Just a normal link without any markup around it should work, too.
+https://endler.dev
+
+Test GZIP compression. (See
+https://github.com/analysis-tools-dev/static-analysis/issues/350)
+`LDRA <https://ldra.com>`__
+
+Some more complex formatting to test that Markdown parsing works. |CC0|
+
+Test HTTP and HTTPS for the same site. http://spinroot.com/cobra/
+https://spinroot.com/cobra/
+
+test@example.com
+
+.. |CC0| image:: https://i.creativecommons.org/p/zero/1.0/88x31.png
+   :target: https://creativecommons.org/publicdomain/zero/1.0/


### PR DESCRIPTION
Lychee is advertising its capability of checking reStructuredText files, so I guess it is a good idea to add these files to the default glob pattern.