### PR TITLE
Always create output file; not only on error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,18 +10,19 @@ jobs:
     continue-on-error: true
     name: Test the lychee link checker action
     steps:
-      # To use this repository's private action,
-      # we must check out the repository
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: test defaults
         uses: ./
         with:
           fail: true
+
       - name: test explicit lychee version
         uses: ./
         with:
           lycheeVersion: 0.9.0
+
       - name: test globs
         uses: ./
         with:
@@ -33,42 +34,51 @@ jobs:
             './**/*.html'
             './**/*.rst'
           fail: true
+
       - name: Install jq
-        run: sudo apt-get install jq     
+        run: sudo apt-get install jq
+
       - name: test workflow inputs - Markdown
         uses: ./
         with:
           args: -v fixtures/TEST.md
           format: json
-          output: /tmp/foo.json
+          output: ${{ github.workspace }}/foo_md.json
           fail: true
+
       - name: Validate JSON - Markdown
-        run: jq empty /tmp/foo.json 
+        run: jq empty ${{ github.workspace }}/foo_md.json
+
       - name: test workflow inputs - rST
         uses: ./
         with:
           args: -v fixtures/TEST.rst
           format: json
-          output: /tmp/foo.json
+          output: ${{ github.workspace }}/foo_rst.json
           fail: true
+
       - name: Validate JSON - rST
-        run: jq empty /tmp/foo.json 
+        run: jq empty ${{ github.workspace }}/foo_rst.json
+
       - name: directory
         uses: ./
         with:
           args: --exclude-mail .
           fail: true
+
       - name: test format override
         uses: ./
         with:
           args: --format markdown -v fixtures/TEST.md
           format: doesnotexist # gets ignored if format set in args
-          output: /tmp/foo.txt
+          output: ${{ github.workspace }}/foo.txt
           fail: true
+
       - name: test debug
         uses: ./
         with:
           debug: true
+
       - name: test custom GitHub token
         uses: ./
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,8 @@ jobs:
             './**/*.html'
             './**/*.rst'
           fail: true
+      - name: Install jq
+        run: sudo apt-get install jq     
       - name: test workflow inputs - Markdown
         uses: ./
         with:
@@ -40,6 +42,8 @@ jobs:
           format: json
           output: /tmp/foo.json
           fail: true
+      - name: Validate JSON - Markdown
+        run: jq empty /tmp/foo.json 
       - name: test workflow inputs - rST
         uses: ./
         with:
@@ -47,6 +51,8 @@ jobs:
           format: json
           output: /tmp/foo.json
           fail: true
+      - name: Validate JSON - rST
+        run: jq empty /tmp/foo.json 
       - name: directory
         uses: ./
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,12 +46,11 @@ jobs:
           output: ${{ github.workspace }}/foo_md.json
           fail: true
 
-      - name: Validate JSON - Markdown
-        run: jq empty ${{ github.workspace }}/foo_md.json
-
-
       - name: List files in workspace
         run: ls -l ${{ github.workspace }}
+
+      - name: Validate JSON - Markdown
+        run: jq empty ${{ github.workspace }}/foo_md.json
 
       - name: test workflow inputs - rST
         uses: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Validate JSON - Markdown
         run: |
           if ! jq empty ${{ github.workspace }}/foo_md.json; then
-            echo "jq command failed"
+            echo "Output file does not exist or is not valid JSON"
             exit 1
           fi
 
@@ -64,7 +64,7 @@ jobs:
       - name: Validate JSON - rST
         run: |
           if ! jq empty ${{ github.workspace }}/foo_rst.json; then
-            echo "jq command failed"
+            echo "Output file does not exist or is not valid JSON"
             exit 1
           fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,11 +46,12 @@ jobs:
           output: ${{ github.workspace }}/foo_md.json
           fail: true
 
-      - name: List files in workspace
-        run: ls -l ${{ github.workspace }}
-
       - name: Validate JSON - Markdown
-        run: jq empty ${{ github.workspace }}/foo_md.json
+        run: |
+          if ! jq empty ${{ github.workspace }}/foo_md.json; then
+            echo "jq command failed"
+            exit 1
+          fi
 
       - name: test workflow inputs - rST
         uses: ./
@@ -60,11 +61,12 @@ jobs:
           output: ${{ github.workspace }}/foo_rst.json
           fail: true
 
-      - name: List files in workspace
-        run: ls -l ${{ github.workspace }}
-        
       - name: Validate JSON - rST
-        run: jq empty ${{ github.workspace }}/foo_rst.json
+        run: |
+          if ! jq empty ${{ github.workspace }}/foo_rst.json; then
+            echo "jq command failed"
+            exit 1
+          fi
 
       - name: directory
         uses: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,10 @@ jobs:
       - name: Validate JSON - Markdown
         run: jq empty ${{ github.workspace }}/foo_md.json
 
+
+      - name: List files in workspace
+        run: ls -l ${{ github.workspace }}
+
       - name: test workflow inputs - rST
         uses: ./
         with:
@@ -57,6 +61,9 @@ jobs:
           output: ${{ github.workspace }}/foo_rst.json
           fail: true
 
+      - name: List files in workspace
+        run: ls -l ${{ github.workspace }}
+        
       - name: Validate JSON - rST
         run: jq empty ${{ github.workspace }}/foo_rst.json
 

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,8 @@ runs:
   steps:
     - name: Install lychee
       run: |
+        # Cleanup artifacts from previous run in case it crashed
+        rm -rf "lychee-v${{ inputs.LYCHEEVERSION }}-x86_64-unknown-linux-gnu.tar.gz" lychee
         curl -sLO "https://github.com/lycheeverse/lychee/releases/download/v${{ inputs.LYCHEEVERSION }}/lychee-v${{ inputs.LYCHEEVERSION }}-x86_64-unknown-linux-gnu.tar.gz"
         tar -xvzf "lychee-v${{ inputs.LYCHEEVERSION }}-x86_64-unknown-linux-gnu.tar.gz"
         rm "lychee-v${{ inputs.LYCHEEVERSION }}-x86_64-unknown-linux-gnu.tar.gz"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,8 +29,8 @@ if [ ! -f "${LYCHEE_TMP}" ]; then
     echo "No output. Check pipeline run to see if lychee panicked." > "${LYCHEE_TMP}"
 fi
 
-# If link errors were found, create a report in the designated directory
-if [ $exit_code -ne 0 ]; then
+# If we have any output, create a report in the designated directory
+if [ -f "${LYCHEE_TMP}" ]; then
     mkdir -p "$(dirname -- "${INPUT_OUTPUT}")"
     cat "${LYCHEE_TMP}" > "${INPUT_OUTPUT}"
 
@@ -52,8 +52,8 @@ fi
 # Pass lychee exit code to next step
 echo "lychee_exit_code=$exit_code" >> $GITHUB_ENV
 
-# If `fail` is set to `true`, propagate the real exit value to the workflow
-# runner. This will cause the pipeline to fail on exit != 0.
+# If `fail` is set to `true`, propagate the real exit code to the workflow
+# runner. This will cause the pipeline to fail on `exit != 0`.
 if [ "$INPUT_FAIL" = true ] ; then
     exit ${exit_code}
 fi

--- a/fixtures/TEST.md
+++ b/fixtures/TEST.md
@@ -15,7 +15,7 @@ Some more complex formatting to test that Markdown parsing works.
 [![CC0](https://i.creativecommons.org/p/zero/1.0/88x31.png)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 Test HTTP and HTTPS for the same site.
-http://spinroot.com/cobra/
-https://spinroot.com/cobra/
+http://google.com/
+https://google.com/
 
 test@example.com


### PR DESCRIPTION
In https://github.com/lycheeverse/lychee-action/issues/198, user @jasongitmail mentioned that the JSON output file was missing when setting `--format json`. In fact, we only create an output file in case the GitHub action run was not successful (exit code != 0). This PR changes that.

We now unconditionally write an output file. Since the file should automatically be cleaned up after the run, there *should* be no negative side effects. I've added a test to make sure this functionality doesn't break in the future.