### PR TITLE
add documentation on using the  param when testing local files (as in…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,18 @@ jobs:
             './**/*.rst'
           fail: true
 
+      - name: test --base argument
+        uses: ./
+        with:
+          args: >-
+            --base .
+            --verbose
+            --no-progress
+            './**/*.md'
+            './**/*.html'
+            './**/*.rst'
+          fail: true
+
       - name: Install jq
         run: sudo apt-get install jq
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Here is how to pass the arguments.
   uses: lycheeverse/lychee-action@v1.8.0
   with:
     # Check all markdown and html files in repo (default)
-    args: --verbose --no-progress './**/*.md' './**/*.html' './**/*.rst'
+    args: --base . --verbose --no-progress './**/*.md' './**/*.html' './**/*.rst'
     # Use json as output format (instead of markdown)
     format: json
     # Use different output file path
@@ -143,7 +143,7 @@ In order to mitigate issues regarding rate limiting or to reduce stress on exter
 - name: Run lychee
   uses: lycheeverse/lychee-action@v1.8.0
   with:
-    args: "--cache --max-cache-age 1d ."
+    args: "--base . --cache --max-cache-age 1d ."
 ```
 
 It will compare and save the cache based on the given key.
@@ -163,7 +163,7 @@ If you need more control over when caches are restored and saved, you can split 
 - name: Run lychee
   uses: lycheeverse/lychee-action@v1.8.0
   with:
-    args: "--cache --max-cache-age 1d ."
+    args: "--base . --cache --max-cache-age 1d ."
 
 - name: Save lychee cache
   uses: actions/cache/save@v3

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ jobs:
           fail: true
 ```
 
-You may want to add additional arguments to the above. In particular if you're testing a site directly from the file-system (as in the above), you'll likely want to set the argument `--base .` to ensure that **all links** (including relative paths) in the files are tested. You don't need to do this if you're testing a hosted site.
+You may want to add additional arguments to the above. In particular if you're testing a site directly from the file-system (as in the above), you'll likely want to set the argument `--base .` to ensure that **all links** (including root-relative paths) in the files are tested. You don't need to do this if you're testing a hosted site.
 
 ```yaml
       - name: Link Checker

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ jobs:
           fail: true
 ```
 
-You may want to add additional arguments to the above. In particular if you're testing a site directly from the file-system (as in the above), you'll likely want to set the argument `--base .` to ensure that **all links** (including root-relative paths) in the files are tested. You don't need to do this if you're testing a hosted site.
+You may want to add additional arguments to the above. In particular, if you're testing a site directly from the file system (as in the above), you'll likely want to set the argument `--base .` to ensure that **all links** (including root-relative paths) in the files are tested. You don't need to do this if you're testing a hosted site.
 
 ```yaml
       - name: Link Checker

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ jobs:
           fail: true
 ```
 
-You may want to add additional arguments to the above.  In particular if you're testing a site directly from the file-system (as in the above), you'll likely want to set the argument `--base .` to ensure that **all links** in the files are tested.  You don't need to do this if you're testing a hosted site.
+You may want to add additional arguments to the above. In particular if you're testing a site directly from the file-system (as in the above), you'll likely want to set the argument `--base .` to ensure that **all links** (including relative paths) in the files are tested. You don't need to do this if you're testing a hosted site.
 
 ```yaml
       - name: Link Checker

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You may want to add additional arguments to the above.  In particular if you're 
         uses: lycheeverse/lychee-action@v1.8.0
         with:
           fail: true
-          args: "--base . --verbose --no-progress './**/*.md' './**/*.html' './**/*.rst'"
+          args: --base . --verbose --no-progress './**/*.md' './**/*.html' './**/*.rst'
 ```
 
 ## Passing arguments

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ jobs:
 
 You may want to add additional arguments to the above.  In particular if you're testing a site directly from the file-system (as in the above), you'll likely want to set the argument `--base .` to ensure that **all links** in the files are tested.  You don't need to do this if you're testing a hosted site.
 
-```
+```yaml
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.8.0
         with:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You may want to add additional arguments to the above.  In particular if you're 
         uses: lycheeverse/lychee-action@v1.8.0
         with:
           fail: true
-          args: "--verbose --no-progress './**/*.md' './**/*.html' './**/*.rst'" --base .
+          args: "--base . --verbose --no-progress './**/*.md' './**/*.html' './**/*.rst'"
 ```
 
 ## Passing arguments

--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ jobs:
           fail: true
 ```
 
+You may want to add additional arguments to the above.  In particular if you're testing a site directly from the file-system (as in the above), you'll likely want to set the argument `--base .` to ensure that **all links** in the files are tested.  You don't need to do this if you're testing a hosted site.
+
+```
+      - name: Link Checker
+        uses: lycheeverse/lychee-action@v1.8.0
+        with:
+          fail: true
+          args: "--verbose --no-progress './**/*.md' './**/*.html' './**/*.rst'" --base .
+```
+
 ## Passing arguments
 
 This action uses [lychee] for link checking.


### PR DESCRIPTION
Per [Issue 1265 in Lychee)](https://github.com/lycheeverse/lychee/issues/1265):  Add documentation about needing to apply the `--base .` parameter when testing on the file-system vs. a hosted site.

I actually think this should apply to both suggested action definitions in this repo since they both test without a domain and are therefore testing on the filesystem.  Neither one specifies a domain or even a localhost address.

Should I also add one that demonstrates testing against a hosted site?  I imagine that was the original intent of the cron job variant.

@mre I think there's a reasonable chance I've misunderstood this behavior and your comments in 1265 - please let me know.