### PR TITLE
fix: Lychee output to file (fixes #214)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,10 +27,8 @@ exit_code=$?
 
 if [ ! -f "${LYCHEE_TMP}" ]; then
     echo "No output. Check pipeline run to see if lychee panicked." > "${LYCHEE_TMP}"
-fi
-
-# If we have any output, create a report in the designated directory
-if [ -f "${LYCHEE_TMP}" ]; then
+else
+    # If we have any output, create a report in the designated directory
     mkdir -p "$(dirname -- "${INPUT_OUTPUT}")"
     cat "${LYCHEE_TMP}" > "${INPUT_OUTPUT}"
 


### PR DESCRIPTION
Currently it evaluates the first `if [ ! -f "${LYCHEE_TMP}" ]; then`, however it skips the second one that's essentially the same check.
This combines them into a single if/else statement so it should start being evaluated.

Fixes #214 