### PR TITLE
Pass custom `token` as input argument to action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,7 +56,7 @@ runs:
       id: lychee
       env:
         # https://github.com/actions/runner/issues/665
-        INPUT_GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+        INPUT_TOKEN: ${{ inputs.TOKEN }}
         INPUT_ARGS: ${{ inputs.ARGS }}
         INPUT_DEBUG: ${{ inputs.DEBUG }}
         INPUT_FAIL: ${{ inputs.FAIL }}


### PR DESCRIPTION
This was an oversight when adding a custom `token` argument. As a consequence, this doesn't work as expected:

```yaml
- uses: lycheeverse/lychee-action@v1.9.0
  with: 
    token: ${{ secrets.CUSTOM_TOKEN }}
```

Thanks to @tobon4 for finding this.
See https://github.com/lycheeverse/lychee/discussions/1353
