### PR TITLE
Adjust for new asset naming scheme

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ runs:
         curl -sLO "https://github.com/lycheeverse/lychee/releases/download/${{ inputs.LYCHEEVERSION }}/lychee-${{ inputs.LYCHEEVERSION }}-x86_64-unknown-linux-gnu.tar.gz"
         tar -xvzf "lychee-${{ inputs.LYCHEEVERSION }}-x86_64-unknown-linux-gnu.tar.gz"
         rm "lychee-${{ inputs.LYCHEEVERSION }}-x86_64-unknown-linux-gnu.tar.gz"
-        install -t "$HOME/.local/bin" -D lychee 
+        install -t "$HOME/.local/bin" -D lychee
         rm lychee
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -48,9 +48,10 @@ runs:
       run: |
         # Cleanup artifacts from previous run in case it crashed
         rm -rf "lychee-${{ inputs.LYCHEEVERSION }}-x86_64-unknown-linux-gnu.tar.gz" lychee
-        curl -sfLO "https://github.com/lycheeverse/lychee/releases/download/${{ inputs.LYCHEEVERSION }}/lychee-${{ inputs.LYCHEEVERSION }}-x86_64-unknown-linux-gnu.tar.gz"
-        tar -xvzf "lychee-${{ inputs.LYCHEEVERSION }}-x86_64-unknown-linux-gnu.tar.gz"
-        rm "lychee-${{ inputs.LYCHEEVERSION }}-x86_64-unknown-linux-gnu.tar.gz"
+        filename='lychee-${{ inputs.LYCHEEVERSION }}-x86_64-unknown-linux-gnu.tar.gz'
+        curl -sfLO "https://github.com/lycheeverse/lychee/releases/download/${{ inputs.LYCHEEVERSION }}/$filename"
+        tar -xvzf "$filename"
+        rm "$filename"
         install -t "$HOME/.local/bin" -D lychee
         rm lychee
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"

--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,10 @@ runs:
       run: |
         # Cleanup artifacts from previous run in case it crashed
         rm -rf "lychee-${{ inputs.LYCHEEVERSION }}-x86_64-unknown-linux-gnu.tar.gz" lychee
-        filename='lychee-${{ inputs.LYCHEEVERSION }}-x86_64-unknown-linux-gnu.tar.gz'
+        case '${{ inputs.LYCHEEVERSION }}' in
+        v0.0*|v0.1[0-5].*) filename='lychee-${{ inputs.LYCHEEVERSION }}-x86_64-unknown-linux-gnu.tar.gz';;
+        *) filename='lychee-x86_64-unknown-linux-gnu.tar.gz'
+        esac
         curl -sfLO "https://github.com/lycheeverse/lychee/releases/download/${{ inputs.LYCHEEVERSION }}/$filename"
         tar -xvzf "$filename"
         rm "$filename"

--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ runs:
       run: |
         # Cleanup artifacts from previous run in case it crashed
         rm -rf "lychee-${{ inputs.LYCHEEVERSION }}-x86_64-unknown-linux-gnu.tar.gz" lychee
-        curl -sLO "https://github.com/lycheeverse/lychee/releases/download/${{ inputs.LYCHEEVERSION }}/lychee-${{ inputs.LYCHEEVERSION }}-x86_64-unknown-linux-gnu.tar.gz"
+        curl -sfLO "https://github.com/lycheeverse/lychee/releases/download/${{ inputs.LYCHEEVERSION }}/lychee-${{ inputs.LYCHEEVERSION }}-x86_64-unknown-linux-gnu.tar.gz"
         tar -xvzf "lychee-${{ inputs.LYCHEEVERSION }}-x86_64-unknown-linux-gnu.tar.gz"
         rm "lychee-${{ inputs.LYCHEEVERSION }}-x86_64-unknown-linux-gnu.tar.gz"
         install -t "$HOME/.local/bin" -D lychee


### PR DESCRIPTION
As of #1464, the naming scheme of the release assets has changed, breaking this here GitHub Action. Currently, this can only be seen with the `nightly` variant, but future releases of `lychee` will see more severe breakages without this PR or something similar.