### PR TITLE
Test latest lychee version tag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,11 @@ jobs:
         with:
           lycheeVersion: nightly
 
+      - name: test latest lychee version
+        uses: ./
+        with:
+          lycheeVersion: latest
+
       - name: test globs
         uses: ./
         with:

--- a/action.yml
+++ b/action.yml
@@ -53,23 +53,22 @@ runs:
         mkdir -p "$HOME/.local/bin"
       shell: bash
 
-    - name: Determine lychee filename
-      id: lychee-filename
+    - name: Determine lychee filename and download URL
+      id: lychee-info
       run: |
         # Older releases (prior to 0.16.x) had the version number in the archive name.
-        # This determines the correct filename based on the version string.
+        # This determines the correct filename and download URL based on the version string.
         if [[ '${{ inputs.lycheeVersion }}' =~ ^v0\.0|^v0\.1[0-5]\. ]]; then
           echo "filename=lychee-${{ inputs.lycheeVersion }}-x86_64-unknown-linux-gnu.tar.gz" >> $GITHUB_OUTPUT
-          echo "tag=${{ inputs.lycheeVersion }}" >> $GITHUB_OUTPUT
+          echo "download_url=https://github.com/lycheeverse/lychee/releases/download/${{ inputs.lycheeVersion }}/lychee-${{ inputs.lycheeVersion }}-x86_64-unknown-linux-gnu.tar.gz" >> $GITHUB_OUTPUT
         else
           echo "filename=lychee-x86_64-unknown-linux-gnu.tar.gz" >> $GITHUB_OUTPUT
-          # Each crate in the workspace has its own tag, so we need to specify the tag for the binary.
-          # The binary is released under the 'lychee' tag, the library under 'lychee-lib'.
-          # For nightly builds, we use the 'nightly' tag.
-          if [[ '${{ inputs.lycheeVersion }}' == 'nightly' ]]; then
-            echo "tag=${{ inputs.lycheeVersion }}" >> $GITHUB_OUTPUT
+          if [[ '${{ inputs.lycheeVersion }}' == 'latest' ]]; then
+            echo "download_url=https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz" >> $GITHUB_OUTPUT
+          elif [[ '${{ inputs.lycheeVersion }}' == 'nightly' ]]; then
+            echo "download_url=https://github.com/lycheeverse/lychee/releases/download/nightly/lychee-x86_64-unknown-linux-gnu.tar.gz" >> $GITHUB_OUTPUT
           else
-            echo "tag=lychee-${{ inputs.lycheeVersion }}" >> $GITHUB_OUTPUT
+            echo "download_url=https://github.com/lycheeverse/lychee/releases/download/lychee-${{ inputs.lycheeVersion }}/lychee-x86_64-unknown-linux-gnu.tar.gz" >> $GITHUB_OUTPUT
           fi
         fi
       shell: bash
@@ -84,7 +83,7 @@ runs:
 
     - name: Download lychee
       run: |
-        curl -sfLO "https://github.com/lycheeverse/lychee/releases/download/${{ steps.lychee-filename.outputs.tag }}/${{ steps.lychee-filename.outputs.filename }}"
+        curl -sfLO "${{ steps.lychee-info.outputs.download_url }}"
       shell: bash
 
     - name: Extract lychee

--- a/action.yml
+++ b/action.yml
@@ -76,7 +76,7 @@ runs:
           elif [[ '${{ inputs.lycheeVersion }}' == 'nightly' ]]; then
             DOWNLOAD_URL="https://github.com/lycheeverse/lychee/releases/download/nightly/${FILENAME}"
           else
-            DOWNLOAD_URL="https://github.com/lycheeverse/lychee/releases/download/lychee-${{ inputs.lycheeVersion }}/${FILENAME}"
+            DOWNLOAD_URL="https://github.com/lycheeverse/lychee/releases/download/${{ inputs.lycheeVersion }}/${FILENAME}"
           fi
         fi
         echo "filename=${FILENAME}" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -53,29 +53,6 @@ runs:
         mkdir -p "$HOME/.local/bin"
       shell: bash
 
-    - name: Determine lychee filename
-      id: lychee-filename
-      run: |
-        # Older releases (prior to 0.16.x) had the version number in the archive name.
-        # This determines the correct filename based on the version string.
-        if [[ '${{ inputs.lycheeVersion }}' =~ ^v0\.0|^v0\.1[0-5]\. ]]; then
-          echo "filename=lychee-${{ inputs.lycheeVersion }}-x86_64-unknown-linux-gnu.tar.gz" >> $GITHUB_OUTPUT
-          echo "tag=${{ inputs.lycheeVersion }}" >> $GITHUB_OUTPUT
-        else
-          echo "filename=lychee-x86_64-unknown-linux-gnu.tar.gz" >> $GITHUB_OUTPUT
-          # Each crate in the workspace has its own tag, so we need to specify the tag for the binary.
-          # The binary is released under the 'lychee' tag, the library under 'lychee-lib'.
-          # For nightly builds, we use the 'nightly' tag.
-          if [[ '${{ inputs.lycheeVersion }}' == 'nightly' ]]; then
-            echo "tag=${{ inputs.lycheeVersion }}" >> $GITHUB_OUTPUT
-          elif [[ '${{ inputs.lycheeVersion }}' == 'latest' ]]; then
-            echo "tag=latest" >> $GITHUB_OUTPUT
-          else
-            echo "tag=lychee-${{ inputs.lycheeVersion }}" >> $GITHUB_OUTPUT
-          fi
-        fi
-      shell: bash
-
     - name: Clean up existing lychee files
       run: |
         # Remove any existing lychee binaries or archives to prevent conflicts
@@ -84,10 +61,32 @@ runs:
         rm -f "${{ steps.lychee-filename.outputs.filename }}"
       shell: bash
 
-    - name: Download lychee
+    - name: Determine lychee filename and download
+      id: lychee-download
       run: |
-        curl -sfLO "https://github.com/lycheeverse/lychee/releases/download/${{ steps.lychee-filename.outputs.tag }}/${{ steps.lychee-filename.outputs.filename }}"
+        # Determine filename and download URL based on version
+        if [[ '${{ inputs.lycheeVersion }}' =~ ^v0\.0|^v0\.1[0-5]\. ]]; then
+          FILENAME="lychee-${{ inputs.lycheeVersion }}-x86_64-unknown-linux-gnu.tar.gz"
+          DOWNLOAD_URL="https://github.com/lycheeverse/lychee/releases/download/${{ inputs.lycheeVersion }}/${FILENAME}"
+        else
+          FILENAME="lychee-x86_64-unknown-linux-gnu.tar.gz"
+          if [[ '${{ inputs.lycheeVersion }}' == 'nightly' ]]; then
+            DOWNLOAD_URL="https://github.com/lycheeverse/lychee/releases/download/nightly/${FILENAME}"
+          elif [[ '${{ inputs.lycheeVersion }}' == 'latest' ]]; then
+            DOWNLOAD_URL="https://github.com/lycheeverse/lychee/releases/latest/download/${FILENAME}"
+          else
+            # 0.16.x and onwards
+            DOWNLOAD_URL="https://github.com/lycheeverse/lychee/releases/download/lychee-${{ inputs.lycheeVersion }}/${FILENAME}"
+          fi
+        fi
+
+        # Download lychee
+        curl -sfLO "${DOWNLOAD_URL}"
+
+        # Output filename for use in later steps
+        echo "filename=${FILENAME}" >> $GITHUB_OUTPUT
       shell: bash
+
 
     - name: Extract lychee
       run: |

--- a/action.yml
+++ b/action.yml
@@ -53,26 +53,6 @@ runs:
         mkdir -p "$HOME/.local/bin"
       shell: bash
 
-    - name: Determine lychee filename and download URL
-      id: lychee-info
-      run: |
-        # Older releases (prior to 0.16.x) had the version number in the archive name.
-        # This determines the correct filename and download URL based on the version string.
-        if [[ '${{ inputs.lycheeVersion }}' =~ ^v0\.0|^v0\.1[0-5]\. ]]; then
-          echo "filename=lychee-${{ inputs.lycheeVersion }}-x86_64-unknown-linux-gnu.tar.gz" >> $GITHUB_OUTPUT
-          echo "download_url=https://github.com/lycheeverse/lychee/releases/download/${{ inputs.lycheeVersion }}/lychee-${{ inputs.lycheeVersion }}-x86_64-unknown-linux-gnu.tar.gz" >> $GITHUB_OUTPUT
-        else
-          echo "filename=lychee-x86_64-unknown-linux-gnu.tar.gz" >> $GITHUB_OUTPUT
-          if [[ '${{ inputs.lycheeVersion }}' == 'latest' ]]; then
-            echo "download_url=https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz" >> $GITHUB_OUTPUT
-          elif [[ '${{ inputs.lycheeVersion }}' == 'nightly' ]]; then
-            echo "download_url=https://github.com/lycheeverse/lychee/releases/download/nightly/lychee-x86_64-unknown-linux-gnu.tar.gz" >> $GITHUB_OUTPUT
-          else
-            echo "download_url=https://github.com/lycheeverse/lychee/releases/download/lychee-${{ inputs.lycheeVersion }}/lychee-x86_64-unknown-linux-gnu.tar.gz" >> $GITHUB_OUTPUT
-          fi
-        fi
-      shell: bash
-
     - name: Clean up existing lychee files
       run: |
         # Remove any existing lychee binaries or archives to prevent conflicts
@@ -81,27 +61,38 @@ runs:
         rm -f "${{ steps.lychee-filename.outputs.filename }}"
       shell: bash
 
-    - name: Download lychee
+    - name: Determine lychee download URL
+      id: get-url
       run: |
-        curl -sfLO "${{ steps.lychee-info.outputs.download_url }}"
+        # Older releases (prior to 0.16.x) had the version number in the archive name.
+        # This determines the correct filename and download URL based on the version string.
+        if [[ '${{ inputs.lycheeVersion }}' =~ ^v0\.0|^v0\.1[0-5]\. ]]; then
+          FILENAME="lychee-${{ inputs.lycheeVersion }}-x86_64-unknown-linux-gnu.tar.gz"
+          DOWNLOAD_URL="https://github.com/lycheeverse/lychee/releases/download/${{ inputs.lycheeVersion }}/${FILENAME}"
+        else
+          FILENAME="lychee-x86_64-unknown-linux-gnu.tar.gz"
+          if [[ '${{ inputs.lycheeVersion }}' == 'latest' ]]; then
+            DOWNLOAD_URL="https://github.com/lycheeverse/lychee/releases/latest/download/${FILENAME}"
+          elif [[ '${{ inputs.lycheeVersion }}' == 'nightly' ]]; then
+            DOWNLOAD_URL="https://github.com/lycheeverse/lychee/releases/download/nightly/${FILENAME}"
+          else
+            DOWNLOAD_URL="https://github.com/lycheeverse/lychee/releases/download/lychee-${{ inputs.lycheeVersion }}/${FILENAME}"
+          fi
+        fi
+        echo "filename=${FILENAME}" >> $GITHUB_OUTPUT
+        echo "download_url=${DOWNLOAD_URL}" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Download lychee
+      run: curl -sfLO "${{ steps.get-url.outputs.url }}"
       shell: bash
 
     - name: Extract lychee
-      run: |
-        tar -xvzf "${{ steps.lychee-filename.outputs.filename }}"
+      run: tar -xzf "${{ steps.get-url.outputs.filename }}"
       shell: bash
 
     - name: Install lychee
-      run: |
-        install -t "$HOME/.local/bin" -D lychee
-      shell: bash
-
-    - name: Clean up installation files
-      run: |
-        # Remove the downloaded archive and any unnecessary files after installation
-        rm -f "${{ steps.lychee-filename.outputs.filename }}"
-        shopt -s extglob
-        rm -f lychee*!(lychee-bin|lychee-lib)
+      run: install -t "$HOME/.local/bin" -D lychee
       shell: bash
 
     - name: Run Lychee
@@ -131,6 +122,14 @@ runs:
         INPUT_JOBSUMMARY: ${{ inputs.JOBSUMMARY }}
         INPUT_OUTPUT: ${{ inputs.OUTPUT }}
       shell: bash
+
+    - name: Cleanup
+      if: always()
+      run: |
+        rm -f "$HOME/.local/bin/lychee" "${{ steps.get-url.outputs.filename }}"
+        rm -rf lychee
+      shell: bash
+
 branding:
   icon: "external-link"
   color: "purple"

--- a/action.yml
+++ b/action.yml
@@ -61,8 +61,8 @@ runs:
         rm -f "${{ steps.lychee-filename.outputs.filename }}"
       shell: bash
 
-    - name: Determine lychee filename and download
-      id: lychee-download
+    - name: Download and extract lychee
+      id: lychee-setup
       run: |
         # Determine filename and download URL based on version
         if [[ '${{ inputs.lycheeVersion }}' =~ ^v0\.0|^v0\.1[0-5]\. ]]; then
@@ -75,22 +75,18 @@ runs:
           elif [[ '${{ inputs.lycheeVersion }}' == 'latest' ]]; then
             DOWNLOAD_URL="https://github.com/lycheeverse/lychee/releases/latest/download/${FILENAME}"
           else
-            # 0.16.x and onwards
             DOWNLOAD_URL="https://github.com/lycheeverse/lychee/releases/download/lychee-${{ inputs.lycheeVersion }}/${FILENAME}"
           fi
         fi
 
-        # Download lychee
+        echo "Downloading from: ${DOWNLOAD_URL}"
         curl -sfLO "${DOWNLOAD_URL}"
+
+        echo "Extracting ${FILENAME}"
+        tar -xvzf "${FILENAME}"
 
         # Output filename for use in later steps
         echo "filename=${FILENAME}" >> $GITHUB_OUTPUT
-      shell: bash
-
-
-    - name: Extract lychee
-      run: |
-        tar -xvzf "${{ steps.lychee-filename.outputs.filename }}"
       shell: bash
 
     - name: Install lychee
@@ -101,7 +97,7 @@ runs:
     - name: Clean up installation files
       run: |
         # Remove the downloaded archive and any unnecessary files after installation
-        rm -f "${{ steps.lychee-filename.outputs.filename }}"
+        rm -f "${{ steps.lychee-setup.outputs.filename }}"
         shopt -s extglob
         rm -f lychee*!(lychee-bin|lychee-lib)
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,29 @@ runs:
         mkdir -p "$HOME/.local/bin"
       shell: bash
 
+    - name: Determine lychee filename
+      id: lychee-filename
+      run: |
+        # Older releases (prior to 0.16.x) had the version number in the archive name.
+        # This determines the correct filename based on the version string.
+        if [[ '${{ inputs.lycheeVersion }}' =~ ^v0\.0|^v0\.1[0-5]\. ]]; then
+          echo "filename=lychee-${{ inputs.lycheeVersion }}-x86_64-unknown-linux-gnu.tar.gz" >> $GITHUB_OUTPUT
+          echo "tag=${{ inputs.lycheeVersion }}" >> $GITHUB_OUTPUT
+        else
+          echo "filename=lychee-x86_64-unknown-linux-gnu.tar.gz" >> $GITHUB_OUTPUT
+          # Each crate in the workspace has its own tag, so we need to specify the tag for the binary.
+          # The binary is released under the 'lychee' tag, the library under 'lychee-lib'.
+          # For nightly builds, we use the 'nightly' tag.
+          if [[ '${{ inputs.lycheeVersion }}' == 'nightly' ]]; then
+            echo "tag=${{ inputs.lycheeVersion }}" >> $GITHUB_OUTPUT
+          elif [[ '${{ inputs.lycheeVersion }}' == 'latest' ]]; then
+            echo "tag=latest" >> $GITHUB_OUTPUT
+          else
+            echo "tag=lychee-${{ inputs.lycheeVersion }}" >> $GITHUB_OUTPUT
+          fi
+        fi
+      shell: bash
+
     - name: Clean up existing lychee files
       run: |
         # Remove any existing lychee binaries or archives to prevent conflicts
@@ -61,38 +84,27 @@ runs:
         rm -f "${{ steps.lychee-filename.outputs.filename }}"
       shell: bash
 
-    - name: Determine lychee download URL
-      id: get-url
-      run: |
-        # Older releases (prior to 0.16.x) had the version number in the archive name.
-        # This determines the correct filename and download URL based on the version string.
-        if [[ '${{ inputs.lycheeVersion }}' =~ ^v0\.0|^v0\.1[0-5]\. ]]; then
-          FILENAME="lychee-${{ inputs.lycheeVersion }}-x86_64-unknown-linux-gnu.tar.gz"
-          DOWNLOAD_URL="https://github.com/lycheeverse/lychee/releases/download/${{ inputs.lycheeVersion }}/${FILENAME}"
-        else
-          FILENAME="lychee-x86_64-unknown-linux-gnu.tar.gz"
-          if [[ '${{ inputs.lycheeVersion }}' == 'latest' ]]; then
-            DOWNLOAD_URL="https://github.com/lycheeverse/lychee/releases/latest/download/${FILENAME}"
-          elif [[ '${{ inputs.lycheeVersion }}' == 'nightly' ]]; then
-            DOWNLOAD_URL="https://github.com/lycheeverse/lychee/releases/download/nightly/${FILENAME}"
-          else
-            DOWNLOAD_URL="https://github.com/lycheeverse/lychee/releases/download/${{ inputs.lycheeVersion }}/${FILENAME}"
-          fi
-        fi
-        echo "filename=${FILENAME}" >> $GITHUB_OUTPUT
-        echo "download_url=${DOWNLOAD_URL}" >> $GITHUB_OUTPUT
-      shell: bash
-
     - name: Download lychee
-      run: curl -sfLO "${{ steps.get-url.outputs.url }}"
+      run: |
+        curl -sfLO "https://github.com/lycheeverse/lychee/releases/download/${{ steps.lychee-filename.outputs.tag }}/${{ steps.lychee-filename.outputs.filename }}"
       shell: bash
 
     - name: Extract lychee
-      run: tar -xzf "${{ steps.get-url.outputs.filename }}"
+      run: |
+        tar -xvzf "${{ steps.lychee-filename.outputs.filename }}"
       shell: bash
 
     - name: Install lychee
-      run: install -t "$HOME/.local/bin" -D lychee
+      run: |
+        install -t "$HOME/.local/bin" -D lychee
+      shell: bash
+
+    - name: Clean up installation files
+      run: |
+        # Remove the downloaded archive and any unnecessary files after installation
+        rm -f "${{ steps.lychee-filename.outputs.filename }}"
+        shopt -s extglob
+        rm -f lychee*!(lychee-bin|lychee-lib)
       shell: bash
 
     - name: Run Lychee
@@ -122,14 +134,6 @@ runs:
         INPUT_JOBSUMMARY: ${{ inputs.JOBSUMMARY }}
         INPUT_OUTPUT: ${{ inputs.OUTPUT }}
       shell: bash
-
-    - name: Cleanup
-      if: always()
-      run: |
-        rm -f "$HOME/.local/bin/lychee" "${{ steps.get-url.outputs.filename }}"
-        rm -rf lychee
-      shell: bash
-
 branding:
   icon: "external-link"
   color: "purple"


### PR DESCRIPTION
In the near future, we'll allow users to specify a `latest` tag as the lychee version.
Related issues: https://github.com/lycheeverse/lychee/issues/1463

This adds a test to make sure this behavior doesn't change in the future.
The build will only succeed once we released a new version of lychee, which is why this remains in draft.

@dscho @axel-kah fyi