### PR TITLE
Bump version to 0.16.x, respect new tag names

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -94,9 +94,22 @@ runs:
         rm -f lychee*!(lychee-bin|lychee-lib)
       shell: bash
 
-    - name: Run lychee
-      id: lychee
-      run: ${{ github.action_path }}/entrypoint.sh
+    - name: Run Lychee
+      id: run-lychee
+      run: |
+        # This step runs lychee and captures its exit code.
+        # We use 'set +e' to prevent the script from exiting immediately if lychee fails.
+        # This allows us to capture the exit code and pass it both to GitHub Actions (via GITHUB_OUTPUT)
+        # and to the shell (via the final 'exit $EXIT_CODE').
+        # This ensures that:
+        # 1. The step fails if lychee fails
+        # 2. The exit code is available as an output for subsequent steps
+        # 3. The exit code is properly propagated to the workflow
+        set +e
+        ${{ github.action_path }}/entrypoint.sh
+        EXIT_CODE=$?
+        echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
+        exit $EXIT_CODE
       env:
         # https://github.com/actions/runner/issues/665
         INPUT_TOKEN: ${{ inputs.TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ runs:
         mkdir -p "$HOME/.local/bin"
       shell: bash
 
-    - name: Determine Lychee filename
+    - name: Determine lychee filename
       id: lychee-filename
       run: |
         if [[ '${{ inputs.lycheeVersion }}' =~ ^v0\.0|^v0\.1[0-5]\. ]]; then
@@ -63,29 +63,38 @@ runs:
         fi
       shell: bash
 
-    - name: Download Lychee
+    - name: Clean up existing lychee files
+      run: |
+        # Remove any existing lychee binaries or archives to prevent conflicts
+        rm -f "$HOME/.local/bin/lychee"
+        rm -f lychee
+        rm -f "${{ steps.lychee-filename.outputs.filename }}"
+      shell: bash
+
+    - name: Download lychee
       run: |
         curl -sfLO "https://github.com/lycheeverse/lychee/releases/download/${{ inputs.lycheeVersion }}/${{ steps.lychee-filename.outputs.filename }}"
       shell: bash
 
-    - name: Extract Lychee
+    - name: Extract lychee
       run: |
         tar -xvzf "${{ steps.lychee-filename.outputs.filename }}"
       shell: bash
 
-    - name: Install Lychee
+    - name: Install lychee
       run: |
         install -t "$HOME/.local/bin" -D lychee
       shell: bash
 
     - name: Clean up installation files
       run: |
+        # Remove the downloaded archive and any unnecessary files after installation
         rm -f "${{ steps.lychee-filename.outputs.filename }}"
         shopt -s extglob
         rm -f lychee*!(lychee-bin|lychee-lib)
       shell: bash
 
-    - name: Run Lychee
+    - name: Run lychee
       id: lychee
       run: ${{ github.action_path }}/entrypoint.sh
       env:
@@ -99,7 +108,6 @@ runs:
         INPUT_JOBSUMMARY: ${{ inputs.JOBSUMMARY }}
         INPUT_OUTPUT: ${{ inputs.OUTPUT }}
       shell: bash
-
 branding:
   icon: "external-link"
   color: "purple"

--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,8 @@ runs:
     - name: Determine lychee filename
       id: lychee-filename
       run: |
+        # Older releases (prior to 0.16.x) had the version number in the archive name.
+        # This determines the correct filename based on the version string.
         if [[ '${{ inputs.lycheeVersion }}' =~ ^v0\.0|^v0\.1[0-5]\. ]]; then
           echo "filename=lychee-${{ inputs.lycheeVersion }}-x86_64-unknown-linux-gnu.tar.gz" >> $GITHUB_OUTPUT
         else

--- a/action.yml
+++ b/action.yml
@@ -67,7 +67,7 @@ runs:
       run: |
         # Remove any existing lychee binaries or archives to prevent conflicts
         rm -f "$HOME/.local/bin/lychee"
-        rm -f lychee
+        rm -rf lychee
         rm -f "${{ steps.lychee-filename.outputs.filename }}"
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ runs:
 
     - name: Download lychee
       run: |
-        curl -sfLO "https://github.com/lycheeverse/lychee/releases/download/${{ inputs.lycheeVersion }}/${{ steps.lychee-filename.outputs.filename }}"
+        curl -sfLO "https://github.com/lycheeverse/lychee/releases/download/${{ steps.lychee-filename.outputs.tag }}/${{ steps.lychee-filename.outputs.filename }}"
       shell: bash
 
     - name: Extract lychee

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,6 @@
 name: "Lychee Broken Link Checker"
 description: "Quickly check links in Markdown, HTML, and text files"
+
 inputs:
   args:
     description: "Lychee arguments (https://github.com/lycheeverse/lychee#commandline-parameters)"
@@ -37,32 +38,56 @@ inputs:
     description: "Your GitHub Access Token, defaults to: {{ github.token }}"
     default: ${{ github.token }}
     required: false
+
 outputs:
   exit_code:
     description: "The exit code returned from Lychee"
-    value: ${{ steps.lychee.outputs.exit_code }}
+    value: ${{ steps.run-lychee.outputs.exit_code }}
+
 runs:
   using: "composite"
   steps:
-    - name: Install lychee
+    - name: Set up environment
       run: |
-        # Cleanup artifacts from previous run in case it crashed
-        rm -rf "lychee-${{ inputs.LYCHEEVERSION }}-x86_64-unknown-linux-gnu.tar.gz" lychee
-        case '${{ inputs.LYCHEEVERSION }}' in
-        v0.0*|v0.1[0-5].*) filename='lychee-${{ inputs.LYCHEEVERSION }}-x86_64-unknown-linux-gnu.tar.gz';;
-        *) filename='lychee-x86_64-unknown-linux-gnu.tar.gz'
-        esac
-        curl -sfLO "https://github.com/lycheeverse/lychee/releases/download/${{ inputs.LYCHEEVERSION }}/$filename"
-        tar -xvzf "$filename"
-        rm "$filename"
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        mkdir -p "$HOME/.local/bin"
+      shell: bash
+
+    - name: Determine Lychee filename
+      id: lychee-filename
+      run: |
+        if [[ '${{ inputs.lycheeVersion }}' =~ ^v0\.0|^v0\.1[0-5]\. ]]; then
+          echo "filename=lychee-${{ inputs.lycheeVersion }}-x86_64-unknown-linux-gnu.tar.gz" >> $GITHUB_OUTPUT
+        else
+          echo "filename=lychee-x86_64-unknown-linux-gnu.tar.gz" >> $GITHUB_OUTPUT
+        fi
+      shell: bash
+
+    - name: Download Lychee
+      run: |
+        curl -sfLO "https://github.com/lycheeverse/lychee/releases/download/${{ inputs.lycheeVersion }}/${{ steps.lychee-filename.outputs.filename }}"
+      shell: bash
+
+    - name: Extract Lychee
+      run: |
+        tar -xvzf "${{ steps.lychee-filename.outputs.filename }}"
+      shell: bash
+
+    - name: Install Lychee
+      run: |
         install -t "$HOME/.local/bin" -D lychee
+      shell: bash
+
+    - name: Clean up installation files
+      run: |
+        rm -f "${{ steps.lychee-filename.outputs.filename }}"
         shopt -s extglob
         rm -f lychee*!(lychee-bin|lychee-lib)
-        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       shell: bash
-    - name: Run lychee
-      run: ${{ github.action_path }}/entrypoint.sh
+
+    - name: Run Lychee
       id: lychee
+      run: ${{ github.action_path }}/entrypoint.sh
       env:
         # https://github.com/actions/runner/issues/665
         INPUT_TOKEN: ${{ inputs.TOKEN }}
@@ -74,6 +99,7 @@ runs:
         INPUT_JOBSUMMARY: ${{ inputs.JOBSUMMARY }}
         INPUT_OUTPUT: ${{ inputs.OUTPUT }}
       shell: bash
+
 branding:
   icon: "external-link"
   color: "purple"

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
     required: false
   lycheeVersion:
     description: "Use custom version of lychee link checker"
-    default: v0.15.0
+    default: v0.16.1
     required: false
   output:
     description: "Summary output file path"
@@ -60,8 +60,17 @@ runs:
         # This determines the correct filename based on the version string.
         if [[ '${{ inputs.lycheeVersion }}' =~ ^v0\.0|^v0\.1[0-5]\. ]]; then
           echo "filename=lychee-${{ inputs.lycheeVersion }}-x86_64-unknown-linux-gnu.tar.gz" >> $GITHUB_OUTPUT
+          echo "tag=${{ inputs.lycheeVersion }}" >> $GITHUB_OUTPUT
         else
           echo "filename=lychee-x86_64-unknown-linux-gnu.tar.gz" >> $GITHUB_OUTPUT
+          # Each crate in the workspace has its own tag, so we need to specify the tag for the binary.
+          # The binary is released under the 'lychee' tag, the library under 'lychee-lib'.
+          # For nightly builds, we use the 'nightly' tag.
+          if [[ '${{ inputs.lycheeVersion }}' == 'nightly' ]]; then
+            echo "tag=${{ inputs.lycheeVersion }}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=lychee-${{ inputs.lycheeVersion }}" >> $GITHUB_OUTPUT
+          fi
         fi
       shell: bash
 
@@ -75,7 +84,7 @@ runs:
 
     - name: Download lychee
       run: |
-        curl -sfLO "https://github.com/lycheeverse/lychee/releases/download/${{ inputs.lycheeVersion }}/${{ steps.lychee-filename.outputs.filename }}"
+        curl -sfLO "https://github.com/lycheeverse/lychee/releases/download/${{ steps.lychee-filename.outputs.tag }}/${{ steps.lychee-filename.outputs.filename }}"
       shell: bash
 
     - name: Extract lychee


### PR DESCRIPTION
With 0.16.x, we started to release the lychee CLI binary separately from the lychee library. As a consequence, the crates get prefixed differently on GitHub releases:

- CLI binary: `lychee-v0.16.0`
- Library: `lychee-lib-v0.16.0`

We need to account for that when downloading the binary, as shown in this commit.

Should be merged after https://github.com/lycheeverse/lychee-action/pull/248, which refactors the pipeline a bit to make discovering those issues easier in the future.

@sebastiaanspeck fyi