### PR TITLE
Don't remove the lychee config file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -99,7 +99,7 @@ runs:
         # Remove the downloaded archive and any unnecessary files after installation
         rm -f "${{ steps.lychee-setup.outputs.filename }}"
         shopt -s extglob
-        rm -f lychee*!(lychee-bin|lychee-lib)
+        rm -f lychee!(*-bin|*-lib|*.toml)
       shell: bash
 
     - name: Run Lychee


### PR DESCRIPTION
This fixes the removal of unncessary files, which currently removes too much, as it removes the config file. But also the `lychee-bin` and `lychee-lib` files:

> $ touch lychee-bin; git status; rm -f lychee*!(lychee-bin|lychee-lib); git status
On branch main
Your branch is up to date with 'origin/main'.
>
> Untracked files:
  (use "git add <file>..." to include in what will be committed)
        lychee-bin
>
> nothing added to commit but untracked files present (use "git add" to track)
On branch main
Your branch is up to date with 'origin/main'.
>
> Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        deleted:    lychee.toml
>
> no changes added to commit (use "git add" and/or "git commit -a")

Here, we can see that not only the `lychee-bin` file has been removed, but the `lychee.toml` file has been removed too (which prevents the action from running properly).

Now, with my new command:

> touch lychee-bin; touch lychee-bar; git status; rm -f lychee!(*-bin|*-lib|*.toml); git status
On branch main
Your branch is up to date with 'origin/main'.
>
> Untracked files:
  (use "git add <file>..." to include in what will be committed)
        lychee-bin
        lychee-bar
>
> nothing added to commit but untracked files present (use "git add" to track)
On branch main
Your branch is up to date with 'origin/main'.
>
> Untracked files:
  (use "git add <file>..." to include in what will be committed)
        lychee-bin
>
> nothing added to commit but untracked files present (use "git add" to track)

Note: I tried running this as `rm -f lychee!(lychee-bin|lychee-lib|*.toml)`, but for some reason, the bin and lib files were still being deleted.