### PR TITLE
Document and use correct permissions in the GitHub workflows

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   linkChecker:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write # required for peter-evans/create-issue-from-file
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Quickly check links in Markdown, HTML, and text files using [lychee].
 
 When used in conjunction with [Create Issue From File], issues will be
-opened when the action finds link problems.
+opened when the action finds link problems (make sure to specify the `issues: write` permission in the [workflow](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions) or the [job](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idpermissions)).
 
 ## Usage
 
@@ -27,6 +27,8 @@ on:
 jobs:
   linkChecker:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write # required for peter-evans/create-issue-from-file
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
When the intention is to potentially create a new GitHub issue, the workflows in question need to set the permissions correctly. Otherwise the workflow runs may fail with:

	Error: Resource not accessible by integration

which is an admittedly _very_ cryptic way to say that the `GITHUB_TOKEN` used in the GitHub workflow run lacks a particular scope to perform the desired operation.

Note: The `GITHUB_TOKEN` used to have read/write permissions for all scopes by default, but that changed to read-only as per https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only; That is the reason why this here change is necessary.

This fixes https://github.com/lycheeverse/lychee-action/issues/194