### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+To report a vulnerability in lychee-action, [open a private vulnerability report](https://github.com/lycheeverse/lychee-action/advisories/new) and you can create a patch on a private fork or, after reporting the problem, our maintainers will fix it as soon as possible.


### PR DESCRIPTION
Hi! I've found a security problem in the action and I want to send a patch, but that would make the patch public and possible attackers could compromise repositories that are using lychee-action.

So to start with the process, I'm opening this to create a *SECURITY.md* document that will enable `Security policy` in the repository `Security` tab.

![image](https://github.com/user-attachments/assets/4d856fe0-fb9b-4250-923e-942304ff0077)

To send the patch in a private fork, that will not be public, I need that someone with write access to the settings enable `Private vulnerability reporting`. The other `Security advisories` can be enabled also without publishing all reports as each report can be marked as public or not later.

Note that there is another approach that maybe you want to take. You can create a unique global *SECURITY.md* file that will apply for each repository on your organization by creating a *lycheeverse/.github* repository and putting the *SECURITY.md* file there.