### PR TITLE
Add missing argument `failIfEmpty`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,17 @@ lychee arguments can be passed to the action via the `args` parameter.
 
 On top of that, the action also supports some additional arguments.
 
-| Argument      | Examples                | Description                                                                      |
-| ------------- | ----------------------- | -------------------------------------------------------------------------------- |
+| Argument      | Examples                | Description                                                                     |
+| ------------- | ----------------------- | ------------------------------------------------------------------------------- |
 | args          | `--cache`, `--insecure` | See [lychee's documentation][lychee-args] for all arguments and values          |
 | debug         | `false`                 | Enable debug output in action (set -x). Helpful for troubleshooting             |
 | fail          | `false`                 | Fail workflow run on error (i.e. when [lychee exit code][lychee-exit] is not 0) |
+| failIfEmpty   | `false`                 | Fail entire pipeline if no links were found                                     |
 | format        | `markdown`, `json`      | Summary output format                                                           |
 | jobSummary    | `false`                 | Write GitHub job summary (on Markdown output only)                              |
 | lycheeVersion | `v0.15.0`, `nightly`    | Overwrite the lychee version to be used                                         |
 | output        | `lychee/results.md`     | Summary output file path                                                        |
-| token         | `""`                    | Custom GitHub token to use for API calls                                               |
+| token         | `""`                    | Custom GitHub token to use for API calls                                        |
 
 See [action.yml](./action.yml) for a full list of supported arguments and their default values.
 
@@ -79,7 +80,7 @@ Here is how to pass the arguments.
     format: json
     # Use different output file path
     output: /tmp/foo.txt
-    # Use a custom GitHub token, which 
+    # Use a custom GitHub token, which
     token: ${{ secrets.CUSTOM_TOKEN }}
     # Don't fail action on broken links
     fail: false
@@ -113,6 +114,7 @@ So in this setup, as long as a user triggers the CI run from the same commit, it
 For restoring the cache, the most recent available one is used (commit hash doesn't matter).
 
 If you need more control over when caches are restored and saved, you can split the cache step and e.g. ensure to always save the cache (also when the link check step fails):
+
 ```yml
 - name: Restore lychee cache
   id: restore-cache

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,7 +32,7 @@ eval lychee ${FORMAT} --output ${LYCHEE_TMP} ${ARGS}
 exit_code=$?
 
 # Overwrite the exit code in case no links were found
-# and `fail-if-empty` is set to `true` (and it is by default)
+# and `failIfEmpty` is set to `true` (and it is by default)
 if [ "${INPUT_FAILIFEMPTY}" = "true" ]; then
     # Explicitly set INPUT_FAIL to true to ensure the script fails
     # if no links are found
@@ -40,7 +40,7 @@ if [ "${INPUT_FAILIFEMPTY}" = "true" ]; then
     # This is a somewhat crude way to check the Markdown output of lychee
     if grep -E 'Total\s+\|\s+0' "${LYCHEE_TMP}"; then
         echo "No links were found. This usually indicates a configuration error." >> "${LYCHEE_TMP}"
-        echo "If this was expected, set 'fail-if-empty: false' in the args." >> "${LYCHEE_TMP}"
+        echo "If this was expected, set 'failIfEmpty: false' in the args." >> "${LYCHEE_TMP}"
         exit_code=1
     fi
 fi


### PR DESCRIPTION
The `failIfEmpty` is missing in the documentation.

This RP also fixed the argument name in `entrypoint.sh`.