### PR TITLE
Fix bugs about the exit code

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Link Checker
+        id: lychee
         uses: ./ # Uses an action in the root directory
         with:
           args: --user-agent "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:59.0) Gecko/20100101 Firefox/59.0" --verbose --exclude spinroot.com --no-progress './**/*.md' './**/*.html' './**/*.rst'
@@ -23,7 +24,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Create Issue From File
-        if: env.exit_code != 0
+        if: ${{ steps.lychee.outputs.exit_code }} != 0
         uses: peter-evans/create-issue-from-file@v5
         with:
           title: Link Checker Report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,6 +125,28 @@ jobs:
           echo "Output set in args and action input should have failed."
           exit 1
 
+      - name: test fail - a lychee error should fail the pipeline
+        id: fail_test
+        uses: ./
+        with:
+          args: --verbose --no-progress foo.bar
+          debug: true
+        continue-on-error: true
+
+      # Explicitly check the exit code of the previous step
+      # as it's expected to fail
+      - name: Check fail
+        if: steps.fail_test.outcome != 'failure'
+        run: |
+          echo "Fail should have failed because the URL is invalid."
+          exit 1
+
+      - name: test disable fail - it's okay if lychee throws an error
+        uses: ./
+        with:
+          args: --no-progress foo.bar
+          fail: false
+
       - name: test failIfEmpty - no links in input should fail the pipeline
         id: fail_if_empty_test
         uses: ./
@@ -146,6 +168,40 @@ jobs:
         with:
           args: --no-progress fixtures/empty.md
           failIfEmpty: false
+
+      - name: test disable failIfEmpty - a lychee error should still fail the pipeline
+        id: fail_but_not_failIfEmpty_test
+        uses: ./
+        with:
+          args: --verbose --no-progress foo.bar
+          failIfEmpty: false
+          debug: true
+        continue-on-error: true
+
+      # Explicitly check the exit code of the previous step
+      # as it's expected to fail
+      - name: Check fail when failIfEmpty is disabled
+        if: steps.fail_but_not_failIfEmpty_test.outcome != 'failure'
+        run: |
+          echo "Fail should have failed because the URL is invalid, even though failIfEmpty is disabled."
+          exit 1
+
+      - name: test disable fail - no links in input should still fail the pipeline
+        id: failIfEmpty_but_not_fail_test
+        uses: ./
+        with:
+          args: --verbose --no-progress fixtures/empty.md
+          fail: false
+          debug: true
+        continue-on-error: true
+
+      # Explicitly check the exit code of the previous step
+      # as it's expected to fail
+      - name: Check failIfEmpty when fail is disabled
+        if: steps.failIfEmpty_but_not_fail_test.outcome != 'failure'
+        run: |
+          echo "FailIfEmpty should have failed because no links were found, even though fail is disabled."
+          exit 1
 
       - name: Install jq
         run: sudo apt-get install jq

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ jobs:
         uses: lycheeverse/lychee-action@v2
 
       - name: Create Issue From File
-        if: env.exit_code != 0
+        if: ${{ steps.lychee.outputs.exit_code }} != 0
         uses: peter-evans/create-issue-from-file@v5
         with:
           title: Link Checker Report

--- a/action.yml
+++ b/action.yml
@@ -106,20 +106,7 @@ runs:
 
     - name: Run Lychee
       id: run-lychee
-      run: |
-        # This step runs lychee and captures its exit code.
-        # We use 'set +e' to prevent the script from exiting immediately if lychee fails.
-        # This allows us to capture the exit code and pass it both to GitHub Actions (via GITHUB_OUTPUT)
-        # and to the shell (via the final 'exit $EXIT_CODE').
-        # This ensures that:
-        # 1. The step fails if lychee fails
-        # 2. The exit code is available as an output for subsequent steps
-        # 3. The exit code is properly propagated to the workflow
-        set +e
-        ${{ github.action_path }}/entrypoint.sh
-        EXIT_CODE=$?
-        echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
-        exit $EXIT_CODE
+      run: ${{ github.action_path }}/entrypoint.sh
       env:
         # https://github.com/actions/runner/issues/665
         INPUT_TOKEN: ${{ inputs.TOKEN }}


### PR DESCRIPTION
-   **fix: Make `fail: false` effective even when `failIfEmpty: true`**

    This commit also makes sure `outputs.exit_code` is “The exit code returned from Lychee”. `failIfEmpty` no longer changes it to `1`.

    Relevant docs:
    - [Setting exit codes for actions - GitHub Docs](https://docs.github.com/en/actions/sharing-automations/creating-actions/setting-exit-codes-for-actions)
    - [exit - POSIX Programmer's Manual](https://manned.org/exit.1posix)

    Relates to #86, #128, #145, #245, and #251.

-   **fix: Update `env.exit_code` to `outputs.exit_code`**

    The previous expression always gives `false`.
    Both `env.exit_code` and `env.lychee_exit_code` are `null`, probably since the docker→composite refactor #128. When GitHub evaluates the expression, it finds the types do not match, and coerces them to number, namely, `null` → `0`.

    See [Evaluate expressions in workflows and actions - GitHub Docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#operators).

    Relates to #253.

No doc update required.