### PR TITLE
Fix if expressions in GitHub actions

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -24,7 +24,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Create Issue From File
-        if: ${{ steps.lychee.outputs.exit_code }} != 0
+        if: steps.lychee.outputs.exit_code != 0
         uses: peter-evans/create-issue-from-file@v5
         with:
           title: Link Checker Report

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ jobs:
         uses: lycheeverse/lychee-action@v2
 
       - name: Create Issue From File
-        if: ${{ steps.lychee.outputs.exit_code }} != 0
+        if: steps.lychee.outputs.exit_code != 0
         uses: peter-evans/create-issue-from-file@v5
         with:
           title: Link Checker Report


### PR DESCRIPTION
`${{ steps.lychee.outputs.exit_code }} != 0` evaluates to `"x != 0"` (a string), and always becomes `true` when GitHub coerces its type.

Relates-to: https://github.com/lycheeverse/lychee-action/pull/262#discussion_r1833397444

Closes #264

