### PR TITLE
Update README.md to include continue-on-error: true in action

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ jobs:
       - name: Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@v2
-        continue-on-error: true
+        with:
+          fail: false
 
       - name: Create Issue From File
         if: ${{ steps.lychee.outputs.exit_code }} != 0

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ jobs:
       - name: Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@v2
+        continue-on-error: true
 
       - name: Create Issue From File
         if: ${{ steps.lychee.outputs.exit_code }} != 0


### PR DESCRIPTION
I had to add
```
continue-on-error: true
```
in order for the next step to fire when there were broken links -- regardless of the `if:`
I tested with adding a Debug echo step after the lychee step.
```
- name: Debug Exit Code
        run: | 
          echo "Lychee exit code: ${{ steps.lychee.outputs.exit_code }}"
```
And this was skipped.