### PR TITLE
feat: support ARM workers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -273,3 +273,22 @@ jobs:
             echo "Expected exit code 1"
             exit 1
           fi
+  lychee-action-arm:
+    runs-on: ubuntu-24.04-arm
+    name: Basic check for ARM-based runners
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: test defaults
+        uses: ./
+
+      - name: test explicit lychee version
+        uses: ./
+        with:
+          lycheeVersion: v0.15.1
+
+      - name: test nightly lychee version
+        uses: ./
+        with:
+          lycheeVersion: nightly

--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,7 @@ runs:
     - name: Download and extract lychee
       id: lychee-setup
       run: |
-        ARCH=$(uname --machine)
+        ARCH=$(uname -m)
         # Determine filename and download URL based on version
         if [[ "${LYCHEE_VERSION}" =~ ^v0\.0|^v0\.1[0-5]\. ]]; then
           FILENAME="lychee-${LYCHEE_VERSION}-${ARCH}-unknown-linux-gnu.tar.gz"

--- a/action.yml
+++ b/action.yml
@@ -64,12 +64,13 @@ runs:
     - name: Download and extract lychee
       id: lychee-setup
       run: |
+        ARCH=$(uname --machine)
         # Determine filename and download URL based on version
         if [[ "${LYCHEE_VERSION}" =~ ^v0\.0|^v0\.1[0-5]\. ]]; then
-          FILENAME="lychee-${LYCHEE_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          FILENAME="lychee-${LYCHEE_VERSION}-${ARCH}-unknown-linux-gnu.tar.gz"
           DOWNLOAD_URL="https://github.com/lycheeverse/lychee/releases/download/${LYCHEE_VERSION}/${FILENAME}"
         else
-          FILENAME="lychee-x86_64-unknown-linux-gnu.tar.gz"
+          FILENAME="lychee-${ARCH}-unknown-linux-gnu.tar.gz"
           if [[ "${LYCHEE_VERSION}" == 'nightly' ]]; then
             DOWNLOAD_URL="https://github.com/lycheeverse/lychee/releases/download/nightly/${FILENAME}"
           elif [[ "${LYCHEE_VERSION}" == 'latest' ]]; then


### PR DESCRIPTION
Added support for ARM-based workers.

Sample test run: https://github.com/LesnyRumcajs/lychee-action/actions/runs/13140393104

I only included a few tests to check that the binary works. We could use `matrix`, but it might be overkill.

Closes https://github.com/lycheeverse/lychee-action/issues/272