### PR TITLE
Fix `lychee` version check

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -44,9 +44,11 @@ fi
 
 CHECKBOX=""
 if [ "${INPUT_CHECKBOX}" = true ]; then
-  # Check if the version is higher than 0.18.1
-  if [ "$(lychee --version | head -n1 | cut -d" " -f4)" -lt 0.18.1 ]; then
-    echo "WARNING: 'checkbox' is not supported in lychee versions lower than 0.18.1. Continuing without 'checkbox'."
+  # Warn if the version is lower than 0.18.1
+  function version_lt() { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" != "$1"; }
+  lychee_version="$(lychee --version | head -n1 | cut -d" " -f2)"
+  if version_lt "$lychee_version" "0.18.1"; then
+    echo "WARNING: 'checkbox' is not supported in lychee versions lower than 0.18.1 (current is $lychee_version). Continuing without 'checkbox'."
   else
     CHECKBOX="--mode task"
   fi


### PR DESCRIPTION
A change introduced in #279 triggers a weird error message. Check https://github.com/simple-icons/simple-icons/actions/runs/14554296040/job/40829177263#step:13:84

The problems are two as I can see: 

- `lychee --version | head -n1 | cut -d" " -f4` returns an empty string. It should be `-f2` as the output of `lychee --version` is `lychee <version>`
- Semver comparisons are not possible using `-lt` in Bash. That raises an `integer expression expected`.