### PR TITLE
Install into $RUNNER_TEMP instead of $HOME

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,11 +61,6 @@ runs:
         echo "$RUNNER_TEMP/lychee/bin" >> "$GITHUB_PATH"
         mkdir -p "$RUNNER_TEMP/lychee/bin"
       shell: bash
-    - name: Clean up existing lychee binary
-      run: |
-        # Remove any existing lychee binary to prevent conflicts
-        rm -f "$RUNNER_TEMP/lychee/bin/lychee"
-      shell: bash
     - name: Download and extract lychee in temp directory
       id: lychee-setup
       run: |

--- a/action.yml
+++ b/action.yml
@@ -54,13 +54,17 @@ runs:
   steps:
     - name: Set up environment
       run: |
-        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-        mkdir -p "$HOME/.local/bin"
+        # Install into $RUNNER_TEMP (not $HOME) so the install path is stable
+        # across composite steps. On some runners $HOME is overridden per step
+        # (e.g. actions/checkout temporarily sets it), which made the PATH
+        # entry from one step and the install in another step diverge.
+        echo "$RUNNER_TEMP/lychee/bin" >> "$GITHUB_PATH"
+        mkdir -p "$RUNNER_TEMP/lychee/bin"
       shell: bash
     - name: Clean up existing lychee binary
       run: |
         # Remove any existing lychee binary to prevent conflicts
-        rm -f "$HOME/.local/bin/lychee"
+        rm -f "$RUNNER_TEMP/lychee/bin/lychee"
       shell: bash
     - name: Download and extract lychee in temp directory
       id: lychee-setup
@@ -110,7 +114,7 @@ runs:
     - name: Install lychee
       run: |
         # Install lychee from the temporary directory
-        install -t "$HOME/.local/bin" -D "${{ steps.lychee-setup.outputs.temp_dir }}/lychee"
+        install -t "$RUNNER_TEMP/lychee/bin" -D "${{ steps.lychee-setup.outputs.temp_dir }}/lychee"
       shell: bash
     - name: Run Lychee
       id: run-lychee


### PR DESCRIPTION
I can already see how this'll be super problematic downstream, but here we go… 😅

`$HOME` is evaluated in two separate composite-action shells ("Set up environment" adds `$HOME/.local/bin` to PATH, "Install lychee" later installs there). On runners where `$HOME` differs between steps — e.g. self-hosted ones where `actions/checkout` overrides it — those two paths diverge and the next step exits with `lychee: command not found`.

This swaps `$HOME/.local/bin` for `$RUNNER_TEMP/lychee/bin`. Same shape, but the path doesn't move between steps. Also gracefully handles containers where `$HOME` might be unset.

Fixes #337.