### PR TITLE
Use musl to avoid GLIBC issues

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -72,10 +72,10 @@ runs:
         ARCH=$(uname -m)
         # Determine filename and download URL based on version
         if [[ "${LYCHEE_VERSION}" =~ ^v0\.0|^v0\.1[0-5]\. ]]; then
-          FILENAME="lychee-${LYCHEE_VERSION}-${ARCH}-unknown-linux-gnu.tar.gz"
+          FILENAME="lychee-${LYCHEE_VERSION}-${ARCH}-unknown-linux-musl.tar.gz"
           DOWNLOAD_URL="https://github.com/lycheeverse/lychee/releases/download/${LYCHEE_VERSION}/${FILENAME}"
         else
-          FILENAME="lychee-${ARCH}-unknown-linux-gnu.tar.gz"
+          FILENAME="lychee-${ARCH}-unknown-linux-musl.tar.gz"
           if [[ "${LYCHEE_VERSION}" == 'nightly' ]]; then
             DOWNLOAD_URL="https://github.com/lycheeverse/lychee/releases/download/nightly/${FILENAME}"
           elif [[ "${LYCHEE_VERSION}" == 'latest' ]]; then


### PR DESCRIPTION
use musl to avoid GLIBC issues.

would be good to add a test too.

I should double check that the old file format is still valid with musl.